### PR TITLE
fix: code > validate > checklist > commit loop 개선

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-02-10
+
+### Fixed
+
+- Code > validate > checklist > commit loop not functioning during code implementation phase — coder agent namespace was incorrect (`dotclaude:coder-{lang}` instead of `dotclaude:coders:coder-{lang}`), orchestrator retry loop was pseudo-code only, per-phase commits excluded planning documents, and quality tools were not auto-detected ([#57](https://github.com/U-lis/dotclaude/issues/57))
+
+### Changed
+
+- code-validator agent now manages the entire validate-fix cycle internally (validator self-loop) instead of orchestrator-mediated retry — validator invokes coder via Task tool, runs quality checks, updates planning documents, and returns final result
+- Quality tool detection is now auto-detected from project configuration files (package.json, pyproject.toml, Cargo.toml, svelte.config.js) with graceful N/A fallback for missing tools
+- Per-phase commits now include updated PHASE_PLAN, GLOBAL, and PHASE_TEST documents alongside code files
+- Orchestrator (`start-new.md`) simplified to single code-validator invocation per phase (no orchestrator-level retry loop)
+- `/dotclaude:code` command aligned with validator-managed loop pattern, expanded pre-commit checklist, and worktree context passing
+
 ## [0.3.1] - 2026-02-03
 
 ### Fixed

--- a/agents/code-validator.md
+++ b/agents/code-validator.md
@@ -22,6 +22,19 @@ The SessionStart hook outputs the configured language (e.g., `[dotclaude] langua
 - **AI-to-AI documents** (SPEC.md, GLOBAL.md, PHASE_*_PLAN.md, PHASE_*_TEST.md, and all documents in `{working_directory}/`): Always write in English regardless of the configured language. These documents are optimized for other AI agents to read.
 - If no language was provided at session start, default to English (en_US).
 
+## Context from Orchestrator
+
+The orchestrator invocation prompt provides these parameters:
+
+- `worktree_path`: Absolute or relative path to the worktree root (used to resolve all file paths)
+- `coder_namespace`: Full Task tool namespace for the coder agent (e.g., `dotclaude:coders:coder-python`)
+- `phase_id`: Phase identifier (e.g., `1`, `2`, `3A`)
+- `plan_path`: Path to the PHASE_{k}_PLAN_{keyword}.md file (relative to worktree)
+- `test_path`: Path to the PHASE_{k}_TEST.md file (relative to worktree)
+- `global_path`: Path to GLOBAL.md (relative to worktree)
+
+If `worktree_path` is not provided, default to `.` (current directory) and log a warning.
+
 ## Validation Target
 
 Current phase documents and code:
@@ -51,57 +64,147 @@ Current phase documents and code:
 └─────────────────────────────────────────────────────────┘
 ```
 
-## Language-Specific Quality Commands
+## Quality Tool Detection and Execution
 
-### Python
+The validator auto-detects which quality tools are available for the current project. Do not assume any specific tool exists.
+
+### Detection Algorithm
+
+```
+1. Inspect project root (worktree_path) for configuration files:
+   - package.json       -> JavaScript/TypeScript project
+   - pyproject.toml     -> Python project
+   - Cargo.toml         -> Rust project
+   - svelte.config.js   -> Svelte project (also has package.json)
+
+2. For each detected project type, determine quality commands:
+
+   Python (pyproject.toml detected):
+     lint:  Check if "ruff" appears in pyproject.toml [tool.ruff] or dependencies -> "ruff check ."
+     type:  Check if "ty" or "mypy" in dependencies -> "ty check" or "mypy ."
+     test:  Check if "pytest" in dependencies -> "pytest"
+
+   JavaScript/TypeScript (package.json detected):
+     lint:  Check package.json devDependencies for "eslint" -> "npx eslint ."
+     type:  Check for tsconfig.json existence -> "npx tsc --noEmit"
+     test:  Check package.json "scripts.test" exists -> "npm test"
+
+   Rust (Cargo.toml detected):
+     lint:  "cargo clippy" (always available with Rust toolchain)
+     type:  N/A (compiler handles types)
+     test:  "cargo test"
+
+   Svelte (svelte.config.js detected):
+     lint:  Check package.json for "eslint" -> "npx eslint ."
+     type:  Check for "svelte-check" in dependencies -> "npx svelte-check"
+     test:  Check package.json "scripts.test" -> "npm test"
+
+3. Before executing each command, verify binary availability:
+   - Run: which {binary} OR command -v {binary}
+   - If not found: mark check as N/A with message "Tool not available: {binary}"
+
+4. Execute available commands and capture output
+5. Report each check as: PASS / FAIL (with details) / N/A (with reason)
+```
+
+### Quality Command Reference
+
+These are reference commands. The validator auto-detects which tools are available per project. Do not assume all commands exist.
+
+#### Python
 ```bash
 ruff check .
 ty check
 pytest
 ```
 
-### JavaScript/TypeScript
+#### JavaScript/TypeScript
 ```bash
 eslint .
 tsc --noEmit
 npm test  # or: jest / vitest
 ```
 
-### Rust
+#### Rust
 ```bash
 cargo clippy
 cargo test
 ```
 
-### Svelte
+#### Svelte
 ```bash
 eslint .
 svelte-check
 npm test  # or: vitest
 ```
 
-## Retry Logic
+## Validate-Fix Loop
 
 ```
-attempt = 0
-max_attempts = 3
-
-while validation_failed and attempt < max_attempts:
-    attempt += 1
-
-    # Report errors to Coder
-    send_fix_instructions(errors)
-
-    # Wait for Coder to fix
-    wait_for_coder_completion()
-
-    # Re-validate
-    validation_failed = run_validation()
-
-if validation_failed:
-    mark_as_skipped()
-    report_special_case()
+┌──────────────────────────────────────────────────────────────┐
+│ VALIDATE-FIX LOOP (max 3 total attempts)                     │
+│                                                              │
+│ attempt = 1                                                  │
+│                                                              │
+│ ┌──────────────────────────────────────────────────────────┐ │
+│ │ Step 1: Run Validation                                   │ │
+│ │   - Check PLAN checklist items against code              │ │
+│ │   - Run quality tools (auto-detected)                    │ │
+│ │   - Check TEST cases implementation                      │ │
+│ └──────────────────────────┬─────────────────────────────┘ │
+│                            │                                 │
+│                     Passed? ─── YES ──→ Go to Document       │
+│                            │            Update (Step 3)      │
+│                           NO                                 │
+│                            │                                 │
+│                   attempt < 3?                               │
+│                      │       │                               │
+│                     YES      NO ──→ Mark as SKIPPED          │
+│                      │              Update GLOBAL.md status   │
+│                      ↓              Return FAIL report        │
+│ ┌──────────────────────────────────────────────────────────┐ │
+│ │ Step 2: Invoke Coder for Fix                             │ │
+│ │                                                          │ │
+│ │ Task(                                                    │ │
+│ │   subagent_type="{coder_namespace}",                     │ │
+│ │   prompt="""                                             │ │
+│ │   ## Task: Fix Validation Errors - Attempt {attempt}/3   │ │
+│ │                                                          │ │
+│ │   ### Working Directory                                  │ │
+│ │   CRITICAL: All operations in: {worktree_path}           │ │
+│ │                                                          │ │
+│ │   ### Errors to Fix                                      │ │
+│ │   {detailed_error_list_from_validation}                   │ │
+│ │                                                          │ │
+│ │   ### Fix Instructions                                   │ │
+│ │   {specific_fix_instructions_per_error}                   │ │
+│ │                                                          │ │
+│ │   ### Scope                                              │ │
+│ │   ONLY fix the listed errors. Do NOT refactor or add     │ │
+│ │   unrelated changes.                                     │ │
+│ │   """                                                    │ │
+│ │ )                                                        │ │
+│ └──────────────────────────┬─────────────────────────────┘ │
+│                            │                                 │
+│                   attempt += 1                               │
+│                   Go to Step 1 (re-validate)                 │
+│                                                              │
+│ ┌──────────────────────────────────────────────────────────┐ │
+│ │ Step 3: Document Update (AFTER final success ONLY)       │ │
+│ │   - Update PHASE_{k}_PLAN_{keyword}.md checklist         │ │
+│ │   - Update GLOBAL.md phase status to "Complete"          │ │
+│ │   - Update PHASE_{k}_TEST.md with results (if applicable)│ │
+│ │   - Return PASS report to orchestrator                   │ │
+│ └──────────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────┘
 ```
+
+**Key Rules:**
+- Document updates (PLAN, GLOBAL, TEST) happen ONLY after final successful validation, never during retry iterations
+- Coder invocation uses the `{coder_namespace}` received from the orchestrator prompt
+- Each error report to the coder must include: file path, line number (if available), error message, and a specific fix suggestion
+- The coder fix prompt must include `{worktree_path}` so the coder operates in the correct directory
+- If all 3 attempts fail, update GLOBAL.md phase status to "Skipped" and return a FAIL report with all unresolved issues
 
 ## Output Format
 
@@ -166,11 +269,17 @@ Manual review required before proceeding.
 
 ## Checklist Update Authority (MANDATORY)
 
+**TIMING: These updates execute ONLY after the final coder completion in the validate-fix loop. Never update documents during retry iterations.**
+
 **These updates are REQUIRED, not optional.**
+
+All file paths below must be resolved relative to `{worktree_path}`. Example: `{worktree_path}/{working_directory}/{subject}/PHASE_{k}_PLAN_{keyword}.md`
 
 Upon successful validation:
 
 ### 1. Update PHASE_{k}_PLAN_{keyword}.md
+
+Read the plan path from the `plan_path` parameter received in the orchestrator prompt. Use `{worktree_path}` to construct the absolute path.
 
 **MUST** check off each completed item:
 
@@ -184,6 +293,8 @@ Upon successful validation:
 
 ### 2. Update GLOBAL.md Phase Overview
 
+Read the global path from the `global_path` parameter received in the orchestrator prompt. Use `{worktree_path}` to construct the absolute path.
+
 **MUST** update phase status in table:
 
 ```markdown
@@ -196,12 +307,17 @@ Status values:
 - `Not Started` → `In Progress` → `Complete`
 - `Skipped` (if validation failed after 3 attempts)
 
-### 3. Verification Before Reporting
+### 3. Update PHASE_{k}_TEST.md
+
+If the TEST document exists at `{test_path}`, update test results based on quality check outcomes. Mark passing tests with [x] and failing tests with [ ] along with failure reason.
+
+### 4. Verification Before Reporting
 
 Before reporting validation complete:
 
 - [ ] All implemented items checked in PHASE_*_PLAN.md
 - [ ] GLOBAL.md phase status updated
+- [ ] PHASE_*_TEST.md updated (if exists)
 - [ ] Files actually modified (not just reported)
 
 **DO NOT report completion without updating documents.**

--- a/claude_works/code-validate-loop/GLOBAL.md
+++ b/claude_works/code-validate-loop/GLOBAL.md
@@ -1,0 +1,102 @@
+# Code > Validate > Checklist > Commit Loop Fix - Global Documentation
+
+## Feature Overview
+
+### Purpose
+
+Restore the intended code > validate > checklist update > commit loop in the dotclaude workflow. The loop is currently non-functional: coder agents are invoked with incorrect namespaces, the validator cannot invoke coder agents for fixes, quality tools are not auto-detected, document updates are skipped during validation, and per-phase commits omit documentation files.
+
+### Problem
+
+After the SPEC-based design phase completes correctly, the code implementation phase fails at multiple points:
+1. Coder agent namespace mismatch (`dotclaude:coder-{lang}` vs correct `dotclaude:coders:coder-{lang}`)
+2. Validator retry logic uses abstract pseudo-code (`send_fix_instructions`, `wait_for_coder_completion`) that agents cannot execute
+3. Orchestrator manages the retry loop externally but provides no concrete implementation
+4. Quality tools are listed statically without project-aware detection or graceful fallback
+5. Document updates (PLAN, GLOBAL, TEST) are not performed by the validator
+6. Per-phase commits only include code files, omitting updated documentation
+
+### Solution
+
+- **Validator self-loop**: code-validator owns the entire validate-fix cycle internally, invoking coder agents via Task tool when fixes are needed (max 3 attempts)
+- **Single invocation**: Orchestrator invokes code-validator ONCE per phase with full context (worktree path, coder namespace, document paths); receives final PASS/FAIL result
+- **Quality auto-detection**: Validator inspects project config files (package.json, pyproject.toml, Cargo.toml, etc.) to determine available tools, verifies command availability, falls back to N/A gracefully
+- **Document update timing**: Validator updates PLAN checklist, GLOBAL phase status, and TEST results AFTER final successful coder completion only (prevents overwrites during retries)
+- **Expanded commit scope**: Per-phase commits include code files AND updated PHASE_PLAN, GLOBAL, PHASE_TEST documents
+
+## Architecture Decisions
+
+### AD-1: Validator Owns the Validate-Fix Loop
+
+**Decision**: The code-validator agent manages the entire validate-fix cycle internally via Task tool invocations of coder agents.
+
+**Rationale**: The orchestrator-mediated loop (current design) uses abstract pseudo-code that agents cannot execute. Moving loop ownership to the validator eliminates the need for orchestrator-level retry management and makes the validator a self-contained unit. The orchestrator invokes the validator once and receives a final result.
+
+**Consequence**: The validator must receive the coder agent namespace from the orchestrator prompt so it can invoke the correct coder agent for fixes.
+
+### AD-2: Coder Namespace Corrected to Match Directory Structure
+
+**Decision**: All coder agent invocations use `dotclaude:coders:coder-{detected_language}` (with `coders:` prefix).
+
+**Rationale**: Coder agents reside in `agents/coders/*.md` (subdirectory). The Task tool namespace must reflect the actual directory path: `coders:coder-{lang}`. The current flat namespace `coder-{lang}` does not resolve to any agent definition.
+
+**Consequence**: All references in `start-new.md`, `code.md`, and `code-validator.md` must use the corrected namespace.
+
+### AD-3: Quality Tools Auto-Detected from Project Config Files
+
+**Decision**: The validator detects available quality tools by inspecting project configuration files (package.json, pyproject.toml, Cargo.toml, etc.) and verifies command availability before execution.
+
+**Rationale**: Projects use different toolchains. Hardcoded quality commands fail when the expected tool is not installed. Auto-detection with graceful N/A fallback ensures validation proceeds with whatever tools are available.
+
+**Consequence**: The validator needs a detection algorithm that maps config files to tool commands and checks binary availability.
+
+### AD-4: Document Updates After Final Coder Completion Only
+
+**Decision**: The validator updates PHASE_PLAN checklist, GLOBAL phase status, and PHASE_TEST results only after the final successful coder completion (not during retry iterations).
+
+**Rationale**: If the validator updates documents during retries and then the coder overwrites files during a fix attempt, the document updates may be lost or inconsistent. Deferring updates to after final success ensures consistency.
+
+**Consequence**: The validator must track validation state internally across retry attempts and only write document updates once at the end.
+
+### AD-5: Commit Scope Expanded to Include Documentation
+
+**Decision**: Per-phase `git add` and `git commit` includes PHASE_PLAN, GLOBAL, and PHASE_TEST documents alongside code files.
+
+**Rationale**: The validator updates these documents as part of the validation cycle. Omitting them from the commit creates a gap where the repository state does not reflect the actual phase completion status.
+
+**Consequence**: Both `start-new.md` and `code.md` must expand their `git add` patterns.
+
+### AD-6: Single-Invocation Orchestrator Prompt
+
+**Decision**: The orchestrator passes all necessary context (worktree_path, coder namespace, phase info, document paths) to the validator in a single prompt. No intermediate orchestrator-validator communication.
+
+**Rationale**: Eliminates the need for orchestrator-level retry loops and intermediate result handling. The validator operates autonomously with full context.
+
+**Consequence**: The validator prompt must be comprehensive, including all paths and context the validator needs to operate independently.
+
+## Phase Overview
+
+| Phase | Description | Status | Dependencies |
+|-------|-------------|--------|--------------|
+| 1 | Core Loop Fix: Rewrite code-validator.md (self-loop, quality detection, document timing) and start-new.md (namespace fix, validator prompt, simplified loop, expanded commit) | Not Started | - |
+| 2 | Align code.md: Mirror Phase 1 patterns (correct namespace, validator-managed loop reference, expanded commit, worktree context) | Not Started | Phase 1 |
+
+## File Structure
+
+### Files to Modify
+
+| File | Phase | Change Summary |
+|------|-------|----------------|
+| `agents/code-validator.md` | 1 | Rewrite retry logic with Task tool coder invocation; add quality tool auto-detection; enhance document update timing; add worktree/namespace context handling |
+| `commands/start-new.md` | 1 | Fix coder namespace (5 locations); rewrite validator prompt with full context; simplify retry loop to single invocation; expand commit scope |
+| `commands/code.md` | 2 | Fix coder namespace in Coder Selection and Task patterns; update validation loop diagram; expand pre-commit checklist; add worktree context to validator invocation |
+
+### Files NOT Modified
+
+| File | Reason |
+|------|--------|
+| `agents/designer.md` | Out of scope (design phase works correctly) |
+| `agents/technical-writer.md` | Out of scope |
+| `commands/init-*.md` | Out of scope |
+| `agents/coders/*.md` | Coder agent definitions do not need changes |
+| `dotclaude-config.json` | No new configuration fields (quality tools auto-detected) |

--- a/claude_works/code-validate-loop/GLOBAL.md
+++ b/claude_works/code-validate-loop/GLOBAL.md
@@ -78,7 +78,7 @@ After the SPEC-based design phase completes correctly, the code implementation p
 
 | Phase | Description | Status | Dependencies |
 |-------|-------------|--------|--------------|
-| 1 | Core Loop Fix: Rewrite code-validator.md (self-loop, quality detection, document timing) and start-new.md (namespace fix, validator prompt, simplified loop, expanded commit) | Not Started | - |
+| 1 | Core Loop Fix: Rewrite code-validator.md (self-loop, quality detection, document timing) and start-new.md (namespace fix, validator prompt, simplified loop, expanded commit) | Complete | - |
 | 2 | Align code.md: Mirror Phase 1 patterns (correct namespace, validator-managed loop reference, expanded commit, worktree context) | Not Started | Phase 1 |
 
 ## File Structure

--- a/claude_works/code-validate-loop/GLOBAL.md
+++ b/claude_works/code-validate-loop/GLOBAL.md
@@ -79,7 +79,7 @@ After the SPEC-based design phase completes correctly, the code implementation p
 | Phase | Description | Status | Dependencies |
 |-------|-------------|--------|--------------|
 | 1 | Core Loop Fix: Rewrite code-validator.md (self-loop, quality detection, document timing) and start-new.md (namespace fix, validator prompt, simplified loop, expanded commit) | Complete | - |
-| 2 | Align code.md: Mirror Phase 1 patterns (correct namespace, validator-managed loop reference, expanded commit, worktree context) | Not Started | Phase 1 |
+| 2 | Align code.md: Mirror Phase 1 patterns (correct namespace, validator-managed loop reference, expanded commit, worktree context) | Complete | Phase 1 |
 
 ## File Structure
 

--- a/claude_works/code-validate-loop/PHASE_1_PLAN_code-validate-loop.md
+++ b/claude_works/code-validate-loop/PHASE_1_PLAN_code-validate-loop.md
@@ -1,0 +1,306 @@
+# Phase 1: Core Loop Fix
+
+## Objective
+
+Establish the interface contract for the validator-managed validate-fix loop by rewriting `agents/code-validator.md` and updating `commands/start-new.md`. After this phase, the code-validator agent can autonomously run validation, invoke coder agents for fixes, update documentation, and return a final result to the orchestrator in a single invocation.
+
+## Prerequisites
+
+- SPEC.md reviewed and approved
+- Access to `agents/code-validator.md`, `commands/start-new.md` source files
+- Understanding of Task tool invocation syntax for subagents
+
+## Instructions
+
+### Part A: Rewrite `agents/code-validator.md`
+
+#### A1. Add Context Reception Section (NEW section, insert after "## Language" section)
+
+Add a new section titled `## Context from Orchestrator` that documents the parameters the validator receives in its invocation prompt:
+
+- `worktree_path`: Absolute or relative path to the worktree root (used to resolve all file paths)
+- `coder_namespace`: Full Task tool namespace for the coder agent (e.g., `dotclaude:coders:coder-python`)
+- `phase_id`: Phase identifier (e.g., `1`, `2`, `3A`)
+- `plan_path`: Path to the PHASE_{k}_PLAN_{keyword}.md file (relative to worktree)
+- `test_path`: Path to the PHASE_{k}_TEST.md file (relative to worktree)
+- `global_path`: Path to GLOBAL.md (relative to worktree)
+
+Include instruction: "If `worktree_path` is not provided, default to `.` (current directory) and log a warning."
+
+#### A2. Add Quality Tool Auto-Detection Section (NEW section, insert after "## Language-Specific Quality Commands")
+
+Replace the current static quality commands section (lines 56-81) with a new section titled `## Quality Tool Detection and Execution`. The section must contain:
+
+**Detection Algorithm:**
+
+```
+1. Inspect project root (worktree_path) for configuration files:
+   - package.json       -> JavaScript/TypeScript project
+   - pyproject.toml     -> Python project
+   - Cargo.toml         -> Rust project
+   - svelte.config.js   -> Svelte project (also has package.json)
+
+2. For each detected project type, determine quality commands:
+
+   Python (pyproject.toml detected):
+     lint:  Check if "ruff" appears in pyproject.toml [tool.ruff] or dependencies -> "ruff check ."
+     type:  Check if "ty" or "mypy" in dependencies -> "ty check" or "mypy ."
+     test:  Check if "pytest" in dependencies -> "pytest"
+
+   JavaScript/TypeScript (package.json detected):
+     lint:  Check package.json devDependencies for "eslint" -> "npx eslint ."
+     type:  Check for tsconfig.json existence -> "npx tsc --noEmit"
+     test:  Check package.json "scripts.test" exists -> "npm test"
+
+   Rust (Cargo.toml detected):
+     lint:  "cargo clippy" (always available with Rust toolchain)
+     type:  N/A (compiler handles types)
+     test:  "cargo test"
+
+   Svelte (svelte.config.js detected):
+     lint:  Check package.json for "eslint" -> "npx eslint ."
+     type:  Check for "svelte-check" in dependencies -> "npx svelte-check"
+     test:  Check package.json "scripts.test" -> "npm test"
+
+3. Before executing each command, verify binary availability:
+   - Run: which {binary} OR command -v {binary}
+   - If not found: mark check as N/A with message "Tool not available: {binary}"
+
+4. Execute available commands and capture output
+5. Report each check as: PASS / FAIL (with details) / N/A (with reason)
+```
+
+**Keep** the existing quality command examples as a reference subsection titled "### Quality Command Reference" but add a note at the top: "These are reference commands. The validator auto-detects which tools are available per project. Do not assume all commands exist."
+
+#### A3. Rewrite Retry Logic Section (lines 86-103)
+
+Replace the entire "## Retry Logic" section (lines 86-103 of current `code-validator.md`) with a new section titled `## Validate-Fix Loop`. The new section must contain:
+
+**Flow Diagram:**
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ VALIDATE-FIX LOOP (max 3 total attempts)                     │
+│                                                              │
+│ attempt = 1                                                  │
+│                                                              │
+│ ┌──────────────────────────────────────────────────────────┐ │
+│ │ Step 1: Run Validation                                   │ │
+│ │   - Check PLAN checklist items against code              │ │
+│ │   - Run quality tools (auto-detected)                    │ │
+│ │   - Check TEST cases implementation                      │ │
+│ └──────────────────────────┬─────────────────────────────┘ │
+│                            │                                 │
+│                     Passed? ─── YES ──→ Go to Document       │
+│                            │            Update (Step 3)      │
+│                           NO                                 │
+│                            │                                 │
+│                   attempt < 3?                               │
+│                      │       │                               │
+│                     YES      NO ──→ Mark as SKIPPED          │
+│                      │              Update GLOBAL.md status   │
+│                      ↓              Return FAIL report        │
+│ ┌──────────────────────────────────────────────────────────┐ │
+│ │ Step 2: Invoke Coder for Fix                             │ │
+│ │                                                          │ │
+│ │ Task(                                                    │ │
+│ │   subagent_type="{coder_namespace}",                     │ │
+│ │   prompt="""                                             │ │
+│ │   ## Task: Fix Validation Errors - Attempt {attempt}/3   │ │
+│ │                                                          │ │
+│ │   ### Working Directory                                  │ │
+│ │   CRITICAL: All operations in: {worktree_path}           │ │
+│ │                                                          │ │
+│ │   ### Errors to Fix                                      │ │
+│ │   {detailed_error_list_from_validation}                   │ │
+│ │                                                          │ │
+│ │   ### Fix Instructions                                   │ │
+│ │   {specific_fix_instructions_per_error}                   │ │
+│ │                                                          │ │
+│ │   ### Scope                                              │ │
+│ │   ONLY fix the listed errors. Do NOT refactor or add     │ │
+│ │   unrelated changes.                                     │ │
+│ │   """                                                    │ │
+│ │ )                                                        │ │
+│ └──────────────────────────┬─────────────────────────────┘ │
+│                            │                                 │
+│                   attempt += 1                               │
+│                   Go to Step 1 (re-validate)                 │
+│                                                              │
+│ ┌──────────────────────────────────────────────────────────┐ │
+│ │ Step 3: Document Update (AFTER final success ONLY)       │ │
+│ │   - Update PHASE_{k}_PLAN_{keyword}.md checklist         │ │
+│ │   - Update GLOBAL.md phase status to "Complete"          │ │
+│ │   - Update PHASE_{k}_TEST.md with results (if applicable)│ │
+│ │   - Return PASS report to orchestrator                   │ │
+│ └──────────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Key Rules:**
+- Document updates (PLAN, GLOBAL, TEST) happen ONLY after final successful validation, never during retry iterations
+- Coder invocation uses the `{coder_namespace}` received from the orchestrator prompt
+- Each error report to the coder must include: file path, line number (if available), error message, and a specific fix suggestion
+- The coder fix prompt must include `{worktree_path}` so the coder operates in the correct directory
+- If all 3 attempts fail, update GLOBAL.md phase status to "Skipped" and return a FAIL report with all unresolved issues
+
+#### A4. Enhance Checklist Update Authority Section (lines 167-207)
+
+Update the "## Checklist Update Authority (MANDATORY)" section to include explicit file path resolution using `worktree_path`. Modify the instructions as follows:
+
+- Add at the beginning of the section: "All file paths below must be resolved relative to `{worktree_path}`. Example: `{worktree_path}/{working_directory}/{subject}/PHASE_{k}_PLAN_{keyword}.md`"
+- In subsection "### 1. Update PHASE_{k}_PLAN_{keyword}.md", add: "Read the plan path from the `plan_path` parameter received in the orchestrator prompt. Use `{worktree_path}` to construct the absolute path."
+- In subsection "### 2. Update GLOBAL.md Phase Overview", add: "Read the global path from the `global_path` parameter received in the orchestrator prompt. Use `{worktree_path}` to construct the absolute path."
+- Add a new subsection "### 3. Update PHASE_{k}_TEST.md" with instruction: "If the TEST document exists at `{test_path}`, update test results based on quality check outcomes. Mark passing tests with [x] and failing tests with [ ] along with failure reason."
+- Renumber existing "### 3. Verification Before Reporting" to "### 4. Verification Before Reporting"
+
+**CRITICAL TIMING RULE**: Add a bold note at the top of the section: "**TIMING: These updates execute ONLY after the final coder completion in the validate-fix loop. Never update documents during retry iterations.**"
+
+---
+
+### Part B: Update `commands/start-new.md`
+
+#### B1. Fix Coder Agent Namespace (5 locations)
+
+Replace the incorrect coder namespace at each of these locations:
+
+**Location 1** - Line 600 (Sequential phase coder invocation):
+Change `subagent_type="dotclaude:coder-{detected_language}"` to `subagent_type="dotclaude:coders:coder-{detected_language}"`
+
+**Location 2** - Line 639 (Parallel phase coder invocation, Call 1):
+Change `subagent_type="dotclaude:coder-{detected_language}"` to `subagent_type="dotclaude:coders:coder-{detected_language}"`
+
+**Location 3** - Line 657 (Parallel phase coder invocation, Call 2):
+Change `subagent_type="dotclaude:coder-{detected_language}"` to `subagent_type="dotclaude:coders:coder-{detected_language}"`
+
+**Location 4** - Line 824 (Parallel execution pattern, Task tool call 1):
+Change `subagent_type: "dotclaude:coder-{detected_language}"` to `subagent_type: "dotclaude:coders:coder-{detected_language}"`
+
+**Location 5** - Line 829 (Parallel execution pattern, Task tool call 2):
+Change `subagent_type: "dotclaude:coder-{detected_language}"` to `subagent_type: "dotclaude:coders:coder-{detected_language}"`
+
+#### B2. Rewrite code-validator Invocation Prompt (lines 694-732)
+
+Replace the entire code-validator Task tool invocation prompt (within the `### code-validator Invocation` section, lines 691-733) with a new comprehensive prompt that passes full context:
+
+```
+Task(
+  subagent_type="dotclaude:code-validator",
+  prompt="""
+## Task: Validate and Fix Phase {phase_id} Implementation
+
+### Context
+Worktree Path: {worktree_path}
+Coder Agent Namespace: dotclaude:coders:coder-{detected_language}
+Phase ID: {phase_id}
+
+### Document Paths (relative to worktree)
+PLAN: {working_directory}/{subject}/PHASE_{phase_id}_PLAN_{keyword}.md
+TEST: {working_directory}/{subject}/PHASE_{phase_id}_TEST.md
+GLOBAL: {working_directory}/{subject}/GLOBAL.md
+
+### Your Authority
+You manage the ENTIRE validate-fix loop for this phase:
+1. Run validation (checklist + quality checks)
+2. If FAIL: invoke the coder agent (via Task tool using the namespace above) with fix instructions
+3. Re-validate after coder fix (max 3 total attempts)
+4. On final SUCCESS: update PLAN checklist, GLOBAL phase status, TEST results
+5. On 3x FAIL: mark phase as SKIPPED in GLOBAL, document unresolved errors
+
+### Important Rules
+- Use {worktree_path} to resolve ALL file paths
+- Pass {worktree_path} to the coder agent in fix prompts
+- Update documents ONLY after final successful validation (not during retries)
+- Auto-detect quality tools from project config files
+- Return final status: PASS or FAIL with comprehensive report
+
+Follow validation procedures from your agent definition.
+"""
+)
+```
+
+#### B3. Simplify Retry Loop (lines 748-762)
+
+Replace the retry loop pseudo-code block (lines 747-762, the section titled "**Retry Loop Pattern**") with a simplified single-invocation pattern:
+
+```
+**After code-validator Completes**:
+
+The code-validator manages the entire validate-fix cycle internally.
+The orchestrator receives only the final result.
+
+Based on the final validation result:
+- **PASS (recommendation: COMMIT)**: Commit the phase (all code files + updated documents)
+  ```bash
+  git add {changed_code_files}
+  git add {working_directory}/{subject}/PHASE_{phase_id}_PLAN_{keyword}.md
+  git add {working_directory}/{subject}/GLOBAL.md
+  git add {working_directory}/{subject}/PHASE_{phase_id}_TEST.md
+  git commit -m "feat/fix: implement phase {phase_id} - {brief_description}"
+  ```
+- **FAIL (recommendation: SKIP)**: Phase already marked as SKIPPED in GLOBAL.md by the validator. Record error and continue to next phase.
+
+There is NO orchestrator-level retry loop. The validator handles all retries internally.
+```
+
+#### B4. Expand Commit Scope (lines 741-742)
+
+Replace the current commit block:
+```bash
+git add {changed_files}
+git commit -m "feat/fix: implement phase {phase_id} - {brief_description}"
+```
+
+With the expanded version:
+```bash
+git add {changed_code_files}
+git add {working_directory}/{subject}/PHASE_{phase_id}_PLAN_{keyword}.md
+git add {working_directory}/{subject}/GLOBAL.md
+git add {working_directory}/{subject}/PHASE_{phase_id}_TEST.md
+git commit -m "feat/fix: implement phase {phase_id} - {brief_description}"
+```
+
+Note: This is the commit block inside the "**PASS**" case (line 740-743). Update it in-place. The B3 section above also references this expanded commit, but B4 specifically targets the original location at lines 741-742.
+
+#### B5. Update "After code-validator Completes" Section (lines 736-762)
+
+The entire block from line 736 ("**After code-validator Completes**:") through line 762 (end of retry loop) should be replaced with the content specified in B3 above. This replaces:
+- The old PASS/FAIL/SKIP branching logic (lines 738-745)
+- The old retry loop pseudo-code (lines 747-762)
+
+## Completion Checklist
+
+### Part A: code-validator.md
+- [ ] A1: New "Context from Orchestrator" section added after "Language" section
+- [ ] A2: Quality Tool Auto-Detection section replaces static commands (lines 56-81)
+- [ ] A2: Quality Command Reference subsection preserved as reference
+- [ ] A2: Detection algorithm covers Python, JS/TS, Rust, Svelte
+- [ ] A2: Binary availability check before execution documented
+- [ ] A2: Graceful N/A fallback documented
+- [ ] A3: Retry Logic section (lines 86-103) replaced with Validate-Fix Loop
+- [ ] A3: Flow diagram shows Task tool coder invocation
+- [ ] A3: Document update happens AFTER final success only
+- [ ] A3: Max 3 attempts enforced
+- [ ] A3: SKIPPED handling for 3x failure documented
+- [ ] A4: File path resolution using worktree_path added
+- [ ] A4: PHASE_TEST.md update subsection added
+- [ ] A4: TIMING rule added (documents updated after final completion only)
+
+### Part B: start-new.md
+- [ ] B1: Namespace fixed at line 600 (`dotclaude:coders:coder-{detected_language}`)
+- [ ] B1: Namespace fixed at line 639
+- [ ] B1: Namespace fixed at line 657
+- [ ] B1: Namespace fixed at line 824
+- [ ] B1: Namespace fixed at line 829
+- [ ] B2: Validator prompt rewritten with full context (worktree, namespace, document paths, loop authority)
+- [ ] B3: Retry loop replaced with single-invocation pattern
+- [ ] B4: Commit scope expanded to include PLAN, GLOBAL, TEST documents
+- [ ] B5: "After code-validator Completes" section updated for single-invocation pattern
+
+## Notes
+
+- Phase 1 establishes the interface contract. Phase 2 aligns `code.md` to match these patterns.
+- The line numbers referenced are from the current (unmodified) versions of the files. If lines shift during editing, use surrounding context to locate the correct sections.
+- All changes are to `.md` instruction files only. No source code changes.
+- The coder namespace correction is a simple string replacement; verify all 5 locations are updated.
+- The validator prompt rewrite (B2) is the most critical change -- it defines the contract between orchestrator and validator.

--- a/claude_works/code-validate-loop/PHASE_1_PLAN_code-validate-loop.md
+++ b/claude_works/code-validate-loop/PHASE_1_PLAN_code-validate-loop.md
@@ -271,31 +271,31 @@ The entire block from line 736 ("**After code-validator Completes**:") through l
 ## Completion Checklist
 
 ### Part A: code-validator.md
-- [ ] A1: New "Context from Orchestrator" section added after "Language" section
-- [ ] A2: Quality Tool Auto-Detection section replaces static commands (lines 56-81)
-- [ ] A2: Quality Command Reference subsection preserved as reference
-- [ ] A2: Detection algorithm covers Python, JS/TS, Rust, Svelte
-- [ ] A2: Binary availability check before execution documented
-- [ ] A2: Graceful N/A fallback documented
-- [ ] A3: Retry Logic section (lines 86-103) replaced with Validate-Fix Loop
-- [ ] A3: Flow diagram shows Task tool coder invocation
-- [ ] A3: Document update happens AFTER final success only
-- [ ] A3: Max 3 attempts enforced
-- [ ] A3: SKIPPED handling for 3x failure documented
-- [ ] A4: File path resolution using worktree_path added
-- [ ] A4: PHASE_TEST.md update subsection added
-- [ ] A4: TIMING rule added (documents updated after final completion only)
+- [x] A1: New "Context from Orchestrator" section added after "Language" section: Verified in agents/code-validator.md:25
+- [x] A2: Quality Tool Auto-Detection section replaces static commands (lines 56-81): Verified in agents/code-validator.md:67 ("## Quality Tool Detection and Execution"), old "## Language-Specific Quality Commands" section no longer exists
+- [x] A2: Quality Command Reference subsection preserved as reference: Verified in agents/code-validator.md:110 ("### Quality Command Reference") with disclaimer note at line 112
+- [x] A2: Detection algorithm covers Python, JS/TS, Rust, Svelte: Verified in agents/code-validator.md:74-100
+- [x] A2: Binary availability check before execution documented: Verified in agents/code-validator.md:102-104 (which/command -v pattern)
+- [x] A2: Graceful N/A fallback documented: Verified in agents/code-validator.md:104 ("Tool not available: {binary}") and line 107 (PASS/FAIL/N/A reporting)
+- [x] A3: Retry Logic section (lines 86-103) replaced with Validate-Fix Loop: Verified in agents/code-validator.md:141 ("## Validate-Fix Loop"), no "## Retry Logic" section exists
+- [x] A3: Flow diagram shows Task tool coder invocation: Verified in agents/code-validator.md:168-186 (Task tool with {coder_namespace})
+- [x] A3: Document update happens AFTER final success only: Verified in agents/code-validator.md:193 ("Step 3: Document Update (AFTER final success ONLY)") and line 203
+- [x] A3: Max 3 attempts enforced: Verified in agents/code-validator.md:145,160 (attempt < 3 check)
+- [x] A3: SKIPPED handling for 3x failure documented: Verified in agents/code-validator.md:162,207
+- [x] A4: File path resolution using worktree_path added: Verified in agents/code-validator.md:276 (path resolution instruction with worktree_path)
+- [x] A4: PHASE_TEST.md update subsection added: Verified in agents/code-validator.md:310 ("### 3. Update PHASE_{k}_TEST.md")
+- [x] A4: TIMING rule added (documents updated after final completion only): Verified in agents/code-validator.md:272 (bold TIMING rule)
 
 ### Part B: start-new.md
-- [ ] B1: Namespace fixed at line 600 (`dotclaude:coders:coder-{detected_language}`)
-- [ ] B1: Namespace fixed at line 639
-- [ ] B1: Namespace fixed at line 657
-- [ ] B1: Namespace fixed at line 824
-- [ ] B1: Namespace fixed at line 829
-- [ ] B2: Validator prompt rewritten with full context (worktree, namespace, document paths, loop authority)
-- [ ] B3: Retry loop replaced with single-invocation pattern
-- [ ] B4: Commit scope expanded to include PLAN, GLOBAL, TEST documents
-- [ ] B5: "After code-validator Completes" section updated for single-invocation pattern
+- [x] B1: Namespace fixed at line 600 (`dotclaude:coders:coder-{detected_language}`): Verified in commands/start-new.md:600
+- [x] B1: Namespace fixed at line 639: Verified in commands/start-new.md:639
+- [x] B1: Namespace fixed at line 657: Verified in commands/start-new.md:657
+- [x] B1: Namespace fixed at line 824: Verified in commands/start-new.md:805 (line shifted due to edits; parallel execution pattern Task call 1)
+- [x] B1: Namespace fixed at line 829: Verified in commands/start-new.md:810 (line shifted due to edits; parallel execution pattern Task call 2)
+- [x] B2: Validator prompt rewritten with full context (worktree, namespace, document paths, loop authority): Verified in commands/start-new.md:691-725
+- [x] B3: Retry loop replaced with single-invocation pattern: Verified in commands/start-new.md:727-743 (single-invocation, explicit "NO orchestrator-level retry loop" at line 743)
+- [x] B4: Commit scope expanded to include PLAN, GLOBAL, TEST documents: Verified in commands/start-new.md:735-738 (git add for PLAN, GLOBAL, TEST)
+- [x] B5: "After code-validator Completes" section updated for single-invocation pattern: Verified in commands/start-new.md:727-743
 
 ## Notes
 

--- a/claude_works/code-validate-loop/PHASE_1_TEST.md
+++ b/claude_works/code-validate-loop/PHASE_1_TEST.md
@@ -1,0 +1,100 @@
+# Phase 1: Test Cases
+
+## Test Coverage Target
+
+>= 70%
+
+These test cases verify the correctness of changes to `agents/code-validator.md` and `commands/start-new.md`. Since all changes are to markdown instruction files (not executable code), "testing" means structural verification, content correctness, and behavioral contract validation through manual or automated inspection.
+
+## Unit Tests
+
+### code-validator.md: Context from Orchestrator Section
+
+- [ ] TC-1.1: Section "## Context from Orchestrator" exists after "## Language" section
+- [ ] TC-1.2: Section documents all 6 required parameters: worktree_path, coder_namespace, phase_id, plan_path, test_path, global_path
+- [ ] TC-1.3: Default behavior documented for missing worktree_path (defaults to ".", warns)
+
+### code-validator.md: Quality Tool Auto-Detection
+
+- [ ] TC-2.1: Section "## Quality Tool Detection and Execution" exists and replaces the old static commands section
+- [ ] TC-2.2: Detection algorithm covers package.json (JS/TS), pyproject.toml (Python), Cargo.toml (Rust), svelte.config.js (Svelte)
+- [ ] TC-2.3: For Python detection: ruff, ty/mypy, pytest commands listed with dependency checks
+- [ ] TC-2.4: For JS/TS detection: eslint, tsc, npm test commands listed with config checks
+- [ ] TC-2.5: For Rust detection: cargo clippy, cargo test commands listed
+- [ ] TC-2.6: For Svelte detection: eslint, svelte-check, npm test commands listed
+- [ ] TC-2.7: Binary availability check instruction present (which/command -v pattern)
+- [ ] TC-2.8: N/A fallback documented with message format "Tool not available: {binary}"
+- [ ] TC-2.9: Quality Command Reference subsection preserved as reference with disclaimer note
+- [ ] TC-2.10: Each check reports as PASS / FAIL (with details) / N/A (with reason)
+
+### code-validator.md: Validate-Fix Loop
+
+- [ ] TC-3.1: Section "## Validate-Fix Loop" exists and replaces old "## Retry Logic" section
+- [ ] TC-3.2: Flow diagram shows 3 steps: Validate -> Invoke Coder -> Document Update
+- [ ] TC-3.3: Coder invocation uses Task tool with `{coder_namespace}` parameter
+- [ ] TC-3.4: Coder fix prompt includes: worktree_path, detailed error list, fix instructions, scope limitation
+- [ ] TC-3.5: Maximum 3 attempts enforced (attempt counter starts at 1, loops while < 3)
+- [ ] TC-3.6: Document update step explicitly states "AFTER final success ONLY"
+- [ ] TC-3.7: On 3x failure: GLOBAL.md updated to "Skipped", FAIL report returned
+- [ ] TC-3.8: No references to old pseudo-code patterns (send_fix_instructions, wait_for_coder_completion)
+
+### code-validator.md: Checklist Update Authority
+
+- [ ] TC-4.1: Timing rule present at top of section: "TIMING: These updates execute ONLY after the final coder completion"
+- [ ] TC-4.2: File path resolution instruction references `{worktree_path}` for constructing absolute paths
+- [ ] TC-4.3: PLAN update subsection references `plan_path` parameter from orchestrator prompt
+- [ ] TC-4.4: GLOBAL update subsection references `global_path` parameter from orchestrator prompt
+- [ ] TC-4.5: New subsection "### 3. Update PHASE_{k}_TEST.md" exists with test result update instructions
+- [ ] TC-4.6: Verification subsection renumbered to "### 4. Verification Before Reporting"
+
+### start-new.md: Coder Namespace Fix
+
+- [ ] TC-5.1: Line ~600 contains `dotclaude:coders:coder-{detected_language}` (sequential phase)
+- [ ] TC-5.2: Line ~639 contains `dotclaude:coders:coder-{detected_language}` (parallel Call 1)
+- [ ] TC-5.3: Line ~657 contains `dotclaude:coders:coder-{detected_language}` (parallel Call 2)
+- [ ] TC-5.4: Line ~824 contains `dotclaude:coders:coder-{detected_language}` (parallel execution pattern 1)
+- [ ] TC-5.5: Line ~829 contains `dotclaude:coders:coder-{detected_language}` (parallel execution pattern 2)
+- [ ] TC-5.6: No remaining occurrences of `dotclaude:coder-{detected_language}` (without `coders:`) in the file
+- [ ] TC-5.7: Corrected namespace matches actual agent directory: `agents/coders/` exists with coder agent files
+
+### start-new.md: Validator Prompt Rewrite
+
+- [ ] TC-6.1: Validator Task tool prompt includes `Worktree Path: {worktree_path}`
+- [ ] TC-6.2: Validator prompt includes `Coder Agent Namespace: dotclaude:coders:coder-{detected_language}`
+- [ ] TC-6.3: Validator prompt includes all 3 document paths (PLAN, TEST, GLOBAL) relative to worktree
+- [ ] TC-6.4: Validator prompt grants loop management authority ("You manage the ENTIRE validate-fix loop")
+- [ ] TC-6.5: Validator prompt instructs: update documents ONLY after final successful validation
+- [ ] TC-6.6: Validator prompt instructs: auto-detect quality tools from project config files
+- [ ] TC-6.7: Validator prompt instructs: return final status (PASS or FAIL) with comprehensive report
+
+### start-new.md: Simplified Retry Loop
+
+- [ ] TC-7.1: No orchestrator-level retry loop exists (no `while attempt < 3` in orchestrator context)
+- [ ] TC-7.2: "After code-validator Completes" section describes single-invocation pattern
+- [ ] TC-7.3: PASS case includes expanded commit (code files + PLAN + GLOBAL + TEST)
+- [ ] TC-7.4: FAIL case states validator already marked SKIPPED in GLOBAL.md
+- [ ] TC-7.5: Explicit statement: "There is NO orchestrator-level retry loop"
+
+### start-new.md: Expanded Commit Scope
+
+- [ ] TC-8.1: git add includes `{working_directory}/{subject}/PHASE_{phase_id}_PLAN_{keyword}.md`
+- [ ] TC-8.2: git add includes `{working_directory}/{subject}/GLOBAL.md`
+- [ ] TC-8.3: git add includes `{working_directory}/{subject}/PHASE_{phase_id}_TEST.md`
+- [ ] TC-8.4: git add still includes changed code files
+
+## Integration Tests
+
+- [ ] IT-1: Validator prompt in start-new.md references parameters that match the "Context from Orchestrator" section in code-validator.md (worktree_path, coder_namespace, phase_id, plan_path, test_path, global_path)
+- [ ] IT-2: Coder namespace in validator prompt matches the corrected namespace used in coder invocations (`dotclaude:coders:coder-{detected_language}`)
+- [ ] IT-3: Document paths in validator prompt use the same `{working_directory}/{subject}/` pattern as the rest of start-new.md
+- [ ] IT-4: The "After code-validator Completes" section in start-new.md is consistent with the validator's output contract (PASS -> COMMIT, FAIL -> SKIP)
+- [ ] IT-5: The commit scope in start-new.md matches the documents the validator is instructed to update (PLAN, GLOBAL, TEST)
+
+## Edge Cases
+
+- [ ] EC-1: Verify code-validator.md handles missing worktree_path gracefully (default to ".", log warning)
+- [ ] EC-2: Verify quality detection handles project with no config files (all checks N/A, validation still proceeds)
+- [ ] EC-3: Verify quality detection handles project with multiple config files (e.g., package.json AND pyproject.toml - both toolchains detected)
+- [ ] EC-4: Verify 3x failure path updates GLOBAL.md to "Skipped" and returns structured FAIL report
+- [ ] EC-5: Verify document update timing constraint is explicitly stated (no updates during retry iterations)
+- [ ] EC-6: Verify coder fix prompt includes scope limitation ("ONLY fix the listed errors")

--- a/claude_works/code-validate-loop/PHASE_1_TEST.md
+++ b/claude_works/code-validate-loop/PHASE_1_TEST.md
@@ -10,91 +10,91 @@ These test cases verify the correctness of changes to `agents/code-validator.md`
 
 ### code-validator.md: Context from Orchestrator Section
 
-- [ ] TC-1.1: Section "## Context from Orchestrator" exists after "## Language" section
-- [ ] TC-1.2: Section documents all 6 required parameters: worktree_path, coder_namespace, phase_id, plan_path, test_path, global_path
-- [ ] TC-1.3: Default behavior documented for missing worktree_path (defaults to ".", warns)
+- [x] TC-1.1: Section "## Context from Orchestrator" exists after "## Language" section (line 25, after Language section ending at line 23)
+- [x] TC-1.2: Section documents all 6 required parameters: worktree_path, coder_namespace, phase_id, plan_path, test_path, global_path (lines 29-34)
+- [x] TC-1.3: Default behavior documented for missing worktree_path (defaults to ".", warns) (line 36)
 
 ### code-validator.md: Quality Tool Auto-Detection
 
-- [ ] TC-2.1: Section "## Quality Tool Detection and Execution" exists and replaces the old static commands section
-- [ ] TC-2.2: Detection algorithm covers package.json (JS/TS), pyproject.toml (Python), Cargo.toml (Rust), svelte.config.js (Svelte)
-- [ ] TC-2.3: For Python detection: ruff, ty/mypy, pytest commands listed with dependency checks
-- [ ] TC-2.4: For JS/TS detection: eslint, tsc, npm test commands listed with config checks
-- [ ] TC-2.5: For Rust detection: cargo clippy, cargo test commands listed
-- [ ] TC-2.6: For Svelte detection: eslint, svelte-check, npm test commands listed
-- [ ] TC-2.7: Binary availability check instruction present (which/command -v pattern)
-- [ ] TC-2.8: N/A fallback documented with message format "Tool not available: {binary}"
-- [ ] TC-2.9: Quality Command Reference subsection preserved as reference with disclaimer note
-- [ ] TC-2.10: Each check reports as PASS / FAIL (with details) / N/A (with reason)
+- [x] TC-2.1: Section "## Quality Tool Detection and Execution" exists and replaces the old static commands section (line 67; no "## Language-Specific Quality Commands" section found)
+- [x] TC-2.2: Detection algorithm covers package.json (JS/TS), pyproject.toml (Python), Cargo.toml (Rust), svelte.config.js (Svelte) (lines 75-78)
+- [x] TC-2.3: For Python detection: ruff, ty/mypy, pytest commands listed with dependency checks (lines 82-85)
+- [x] TC-2.4: For JS/TS detection: eslint, tsc, npm test commands listed with config checks (lines 87-90)
+- [x] TC-2.5: For Rust detection: cargo clippy, cargo test commands listed (lines 92-95)
+- [x] TC-2.6: For Svelte detection: eslint, svelte-check, npm test commands listed (lines 97-100)
+- [x] TC-2.7: Binary availability check instruction present (which/command -v pattern) (lines 102-103)
+- [x] TC-2.8: N/A fallback documented with message format "Tool not available: {binary}" (line 104)
+- [x] TC-2.9: Quality Command Reference subsection preserved as reference with disclaimer note (line 110 heading, line 112 disclaimer)
+- [x] TC-2.10: Each check reports as PASS / FAIL (with details) / N/A (with reason) (line 107)
 
 ### code-validator.md: Validate-Fix Loop
 
-- [ ] TC-3.1: Section "## Validate-Fix Loop" exists and replaces old "## Retry Logic" section
-- [ ] TC-3.2: Flow diagram shows 3 steps: Validate -> Invoke Coder -> Document Update
-- [ ] TC-3.3: Coder invocation uses Task tool with `{coder_namespace}` parameter
-- [ ] TC-3.4: Coder fix prompt includes: worktree_path, detailed error list, fix instructions, scope limitation
-- [ ] TC-3.5: Maximum 3 attempts enforced (attempt counter starts at 1, loops while < 3)
-- [ ] TC-3.6: Document update step explicitly states "AFTER final success ONLY"
-- [ ] TC-3.7: On 3x failure: GLOBAL.md updated to "Skipped", FAIL report returned
-- [ ] TC-3.8: No references to old pseudo-code patterns (send_fix_instructions, wait_for_coder_completion)
+- [x] TC-3.1: Section "## Validate-Fix Loop" exists and replaces old "## Retry Logic" section (line 141; no "## Retry Logic" found)
+- [x] TC-3.2: Flow diagram shows 3 steps: Validate -> Invoke Coder -> Document Update (lines 150, 166, 192)
+- [x] TC-3.3: Coder invocation uses Task tool with `{coder_namespace}` parameter (line 169)
+- [x] TC-3.4: Coder fix prompt includes: worktree_path, detailed error list, fix instructions, scope limitation (lines 174, 177, 180, 183-184)
+- [x] TC-3.5: Maximum 3 attempts enforced (attempt counter starts at 1, loops while < 3) (lines 147, 160)
+- [x] TC-3.6: Document update step explicitly states "AFTER final success ONLY" (line 193, line 203)
+- [x] TC-3.7: On 3x failure: GLOBAL.md updated to "Skipped", FAIL report returned (lines 162-164, line 207)
+- [x] TC-3.8: No references to old pseudo-code patterns (send_fix_instructions, wait_for_coder_completion) (grep confirmed: no matches)
 
 ### code-validator.md: Checklist Update Authority
 
-- [ ] TC-4.1: Timing rule present at top of section: "TIMING: These updates execute ONLY after the final coder completion"
-- [ ] TC-4.2: File path resolution instruction references `{worktree_path}` for constructing absolute paths
-- [ ] TC-4.3: PLAN update subsection references `plan_path` parameter from orchestrator prompt
-- [ ] TC-4.4: GLOBAL update subsection references `global_path` parameter from orchestrator prompt
-- [ ] TC-4.5: New subsection "### 3. Update PHASE_{k}_TEST.md" exists with test result update instructions
-- [ ] TC-4.6: Verification subsection renumbered to "### 4. Verification Before Reporting"
+- [x] TC-4.1: Timing rule present at top of section: "TIMING: These updates execute ONLY after the final coder completion" (line 272)
+- [x] TC-4.2: File path resolution instruction references `{worktree_path}` for constructing absolute paths (line 276)
+- [x] TC-4.3: PLAN update subsection references `plan_path` parameter from orchestrator prompt (line 282)
+- [x] TC-4.4: GLOBAL update subsection references `global_path` parameter from orchestrator prompt (line 296)
+- [x] TC-4.5: New subsection "### 3. Update PHASE_{k}_TEST.md" exists with test result update instructions (line 310)
+- [x] TC-4.6: Verification subsection renumbered to "### 4. Verification Before Reporting" (line 314)
 
 ### start-new.md: Coder Namespace Fix
 
-- [ ] TC-5.1: Line ~600 contains `dotclaude:coders:coder-{detected_language}` (sequential phase)
-- [ ] TC-5.2: Line ~639 contains `dotclaude:coders:coder-{detected_language}` (parallel Call 1)
-- [ ] TC-5.3: Line ~657 contains `dotclaude:coders:coder-{detected_language}` (parallel Call 2)
-- [ ] TC-5.4: Line ~824 contains `dotclaude:coders:coder-{detected_language}` (parallel execution pattern 1)
-- [ ] TC-5.5: Line ~829 contains `dotclaude:coders:coder-{detected_language}` (parallel execution pattern 2)
-- [ ] TC-5.6: No remaining occurrences of `dotclaude:coder-{detected_language}` (without `coders:`) in the file
-- [ ] TC-5.7: Corrected namespace matches actual agent directory: `agents/coders/` exists with coder agent files
+- [x] TC-5.1: Line ~600 contains `dotclaude:coders:coder-{detected_language}` (sequential phase) (line 600)
+- [x] TC-5.2: Line ~639 contains `dotclaude:coders:coder-{detected_language}` (parallel Call 1) (line 639)
+- [x] TC-5.3: Line ~657 contains `dotclaude:coders:coder-{detected_language}` (parallel Call 2) (line 657)
+- [x] TC-5.4: Line ~824 contains `dotclaude:coders:coder-{detected_language}` (parallel execution pattern 1) (line 805 after edits)
+- [x] TC-5.5: Line ~829 contains `dotclaude:coders:coder-{detected_language}` (parallel execution pattern 2) (line 810 after edits)
+- [x] TC-5.6: No remaining occurrences of `dotclaude:coder-{detected_language}` (without `coders:`) in the file (grep confirmed: no matches)
+- [x] TC-5.7: Corrected namespace matches actual agent directory: `agents/coders/` exists with coder agent files (directory contains: _base.md, javascript.md, python.md, rust.md, sql.md, svelte.md)
 
 ### start-new.md: Validator Prompt Rewrite
 
-- [ ] TC-6.1: Validator Task tool prompt includes `Worktree Path: {worktree_path}`
-- [ ] TC-6.2: Validator prompt includes `Coder Agent Namespace: dotclaude:coders:coder-{detected_language}`
-- [ ] TC-6.3: Validator prompt includes all 3 document paths (PLAN, TEST, GLOBAL) relative to worktree
-- [ ] TC-6.4: Validator prompt grants loop management authority ("You manage the ENTIRE validate-fix loop")
-- [ ] TC-6.5: Validator prompt instructs: update documents ONLY after final successful validation
-- [ ] TC-6.6: Validator prompt instructs: auto-detect quality tools from project config files
-- [ ] TC-6.7: Validator prompt instructs: return final status (PASS or FAIL) with comprehensive report
+- [x] TC-6.1: Validator Task tool prompt includes `Worktree Path: {worktree_path}` (line 698)
+- [x] TC-6.2: Validator prompt includes `Coder Agent Namespace: dotclaude:coders:coder-{detected_language}` (line 699)
+- [x] TC-6.3: Validator prompt includes all 3 document paths (PLAN, TEST, GLOBAL) relative to worktree (lines 703-705)
+- [x] TC-6.4: Validator prompt grants loop management authority ("You manage the ENTIRE validate-fix loop") (line 708)
+- [x] TC-6.5: Validator prompt instructs: update documents ONLY after final successful validation (line 718)
+- [x] TC-6.6: Validator prompt instructs: auto-detect quality tools from project config files (line 719)
+- [x] TC-6.7: Validator prompt instructs: return final status (PASS or FAIL) with comprehensive report (line 720)
 
 ### start-new.md: Simplified Retry Loop
 
-- [ ] TC-7.1: No orchestrator-level retry loop exists (no `while attempt < 3` in orchestrator context)
-- [ ] TC-7.2: "After code-validator Completes" section describes single-invocation pattern
-- [ ] TC-7.3: PASS case includes expanded commit (code files + PLAN + GLOBAL + TEST)
-- [ ] TC-7.4: FAIL case states validator already marked SKIPPED in GLOBAL.md
-- [ ] TC-7.5: Explicit statement: "There is NO orchestrator-level retry loop"
+- [x] TC-7.1: No orchestrator-level retry loop exists (no `while attempt < 3` in orchestrator context) -- Note: line 850 has a generic `while attempt < 3` but it is in the general "Error Handling > Subagent Failure" section, not the code-validator specific section
+- [x] TC-7.2: "After code-validator Completes" section describes single-invocation pattern (lines 727-743)
+- [x] TC-7.3: PASS case includes expanded commit (code files + PLAN + GLOBAL + TEST) (lines 735-738)
+- [x] TC-7.4: FAIL case states validator already marked SKIPPED in GLOBAL.md (line 741)
+- [x] TC-7.5: Explicit statement: "There is NO orchestrator-level retry loop" (line 743)
 
 ### start-new.md: Expanded Commit Scope
 
-- [ ] TC-8.1: git add includes `{working_directory}/{subject}/PHASE_{phase_id}_PLAN_{keyword}.md`
-- [ ] TC-8.2: git add includes `{working_directory}/{subject}/GLOBAL.md`
-- [ ] TC-8.3: git add includes `{working_directory}/{subject}/PHASE_{phase_id}_TEST.md`
-- [ ] TC-8.4: git add still includes changed code files
+- [x] TC-8.1: git add includes `{working_directory}/{subject}/PHASE_{phase_id}_PLAN_{keyword}.md` (line 736)
+- [x] TC-8.2: git add includes `{working_directory}/{subject}/GLOBAL.md` (line 737)
+- [x] TC-8.3: git add includes `{working_directory}/{subject}/PHASE_{phase_id}_TEST.md` (line 738)
+- [x] TC-8.4: git add still includes changed code files (line 735: `git add {changed_code_files}`)
 
 ## Integration Tests
 
-- [ ] IT-1: Validator prompt in start-new.md references parameters that match the "Context from Orchestrator" section in code-validator.md (worktree_path, coder_namespace, phase_id, plan_path, test_path, global_path)
-- [ ] IT-2: Coder namespace in validator prompt matches the corrected namespace used in coder invocations (`dotclaude:coders:coder-{detected_language}`)
-- [ ] IT-3: Document paths in validator prompt use the same `{working_directory}/{subject}/` pattern as the rest of start-new.md
-- [ ] IT-4: The "After code-validator Completes" section in start-new.md is consistent with the validator's output contract (PASS -> COMMIT, FAIL -> SKIP)
-- [ ] IT-5: The commit scope in start-new.md matches the documents the validator is instructed to update (PLAN, GLOBAL, TEST)
+- [x] IT-1: Validator prompt in start-new.md references parameters that match the "Context from Orchestrator" section in code-validator.md (worktree_path, coder_namespace, phase_id, plan_path, test_path, global_path) -- Validator prompt (lines 696-722) passes worktree_path, coder namespace, phase_id, and document paths (PLAN, TEST, GLOBAL); code-validator.md Context section (lines 29-34) documents all 6 parameters
+- [x] IT-2: Coder namespace in validator prompt matches the corrected namespace used in coder invocations (`dotclaude:coders:coder-{detected_language}`) -- Both validator prompt (line 699) and coder invocations (lines 600, 639, 657, 805, 810) use identical namespace format
+- [x] IT-3: Document paths in validator prompt use the same `{working_directory}/{subject}/` pattern as the rest of start-new.md -- Lines 703-705 use `{working_directory}/{subject}/` consistent with patterns throughout start-new.md
+- [x] IT-4: The "After code-validator Completes" section in start-new.md is consistent with the validator's output contract (PASS -> COMMIT, FAIL -> SKIP) -- Lines 732-741: PASS leads to commit, FAIL notes validator already marked SKIPPED
+- [x] IT-5: The commit scope in start-new.md matches the documents the validator is instructed to update (PLAN, GLOBAL, TEST) -- Lines 736-738 add PLAN, GLOBAL, TEST; code-validator.md lines 194-196 update the same three documents
 
 ## Edge Cases
 
-- [ ] EC-1: Verify code-validator.md handles missing worktree_path gracefully (default to ".", log warning)
-- [ ] EC-2: Verify quality detection handles project with no config files (all checks N/A, validation still proceeds)
-- [ ] EC-3: Verify quality detection handles project with multiple config files (e.g., package.json AND pyproject.toml - both toolchains detected)
-- [ ] EC-4: Verify 3x failure path updates GLOBAL.md to "Skipped" and returns structured FAIL report
-- [ ] EC-5: Verify document update timing constraint is explicitly stated (no updates during retry iterations)
-- [ ] EC-6: Verify coder fix prompt includes scope limitation ("ONLY fix the listed errors")
+- [x] EC-1: Verify code-validator.md handles missing worktree_path gracefully (default to ".", log warning) -- Line 36: explicit instruction
+- [x] EC-2: Verify quality detection handles project with no config files (all checks N/A, validation still proceeds) -- Lines 74-78 inspect for config files; lines 102-107 show N/A fallback when binary not found; detection algorithm proceeds through all project types
+- [x] EC-3: Verify quality detection handles project with multiple config files (e.g., package.json AND pyproject.toml - both toolchains detected) -- Line 80: "For each detected project type" implies all detected types are processed
+- [x] EC-4: Verify 3x failure path updates GLOBAL.md to "Skipped" and returns structured FAIL report -- Lines 162-164 (SKIPPED path in flow diagram), line 207 (key rule), lines 255-268 (skip report template)
+- [x] EC-5: Verify document update timing constraint is explicitly stated (no updates during retry iterations) -- Line 272 (bold TIMING rule), line 203 (key rule: "never during retry iterations")
+- [x] EC-6: Verify coder fix prompt includes scope limitation ("ONLY fix the listed errors") -- Lines 183-184 in flow diagram: "ONLY fix the listed errors. Do NOT refactor or add unrelated changes."

--- a/claude_works/code-validate-loop/PHASE_2_PLAN_code-validate-loop.md
+++ b/claude_works/code-validate-loop/PHASE_2_PLAN_code-validate-loop.md
@@ -1,0 +1,227 @@
+# Phase 2: Align code.md
+
+## Objective
+
+Update `commands/code.md` to mirror the patterns established in Phase 1. After this phase, the standalone `/dotclaude:code` command uses the same corrected coder namespace, validator-managed loop, worktree context passing, and expanded commit scope as the orchestrator (`start-new.md`).
+
+## Prerequisites
+
+- Phase 1 completed (code-validator.md rewritten, start-new.md updated)
+- Access to `commands/code.md` source file
+- Understanding of the validator-managed loop contract established in Phase 1
+
+## Instructions
+
+### C1. Fix Coder Namespace in Coder Selection Table (around line 153-159)
+
+The "## Coder Selection" table currently lists agent file paths but does not show the Task tool namespace. The table itself does not contain namespace strings, but the surrounding invocation patterns do.
+
+Search the entire file for any occurrence of `dotclaude:coder-` (without `coders:` prefix) and replace with `dotclaude:coders:coder-`. Specifically:
+
+- Any Task tool invocation pattern referencing `subagent_type="dotclaude:coder-{language}"` must be corrected to `subagent_type="dotclaude:coders:coder-{language}"`
+- The Coder Selection table itself (lines 153-159) uses file paths (`coders/python.md` etc.) which are correct. However, add a note above the table: "Task tool namespace: `dotclaude:coders:coder-{language}` (maps to `agents/coders/{language}.md`)"
+
+### C2. Update Validation Loop Diagram (lines 82-98)
+
+Replace the current "### Validation Loop" diagram (lines 82-98) in the "## Mandatory Validation" section with an updated diagram that reflects the validator-managed loop:
+
+```
+### Validation Loop
+
+The code-validator manages the entire validate-fix cycle internally.
+The orchestrator (this command) invokes the validator ONCE and receives the final result.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Coder completes implementation                          │
+│         ↓                                               │
+│ Invoke code-validator (SINGLE invocation)               │
+│   - Passes: worktree_path, coder namespace,             │
+│     phase_id, document paths                            │
+│         ↓                                               │
+│ code-validator internally:                              │
+│   ┌──────────────────────────────────────────────┐      │
+│   │ Validate → FAIL? → Invoke coder for fix      │      │
+│   │     ↑                    ↓                   │      │
+│   │     └──── Re-validate ←──┘ (max 3 attempts)  │      │
+│   └──────────────────────────────────────────────┘      │
+│         ↓                                               │
+│ code-validator returns final result:                    │
+│   - PASS: documents updated (PLAN, GLOBAL, TEST)        │
+│   - FAIL: phase marked SKIPPED in GLOBAL                │
+│         ↓                                               │
+│ Orchestrator commits or skips based on result           │
+└─────────────────────────────────────────────────────────┘
+```
+```
+
+### C3. Update Mandatory Validation Section (lines 68-98)
+
+In the "## Mandatory Validation (CRITICAL)" section, update the "### Validation Requirements" subsection (lines 74-78) to reflect the single-invocation pattern:
+
+Replace:
+```
+After Coder completes implementation:
+
+1. **MUST** invoke code-validator agent
+2. **MUST** wait for validation result
+3. **MUST** ensure checklist updates are complete before commit
+```
+
+With:
+```
+After Coder completes implementation:
+
+1. **MUST** invoke code-validator agent with full context (worktree path, coder namespace, document paths)
+2. **MUST** wait for final validation result (validator manages retries internally)
+3. **MUST** ensure validator has updated PLAN checklist, GLOBAL status, and TEST results before commit
+4. **MUST** include updated documents in the commit (not just code files)
+```
+
+### C4. Update Pre-Commit Checklist (lines 100-109)
+
+Expand the "### Pre-Commit Checklist" to include document files. Replace the current checklist:
+
+```
+Before `git add` and `git commit`:
+
+- [ ] code-validator invoked and completed
+- [ ] All items in PHASE_{k}_PLAN.md checked off
+- [ ] GLOBAL.md phase status updated to "Complete"
+- [ ] Quality checks passed (linter, type check, tests)
+```
+
+With:
+
+```
+Before `git add` and `git commit`:
+
+- [ ] code-validator invoked with full context and completed (final result received)
+- [ ] All items in PHASE_{k}_PLAN.md checked off (by validator)
+- [ ] GLOBAL.md phase status updated to "Complete" (by validator)
+- [ ] Quality checks passed or marked N/A (by validator, auto-detected per project)
+- [ ] git add includes: changed code files
+- [ ] git add includes: {working_directory}/{subject}/PHASE_{k}_PLAN_{keyword}.md
+- [ ] git add includes: {working_directory}/{subject}/GLOBAL.md
+- [ ] git add includes: {working_directory}/{subject}/PHASE_{k}_TEST.md (if modified)
+```
+
+### C5. Add Worktree Context to Validator Invocation
+
+In the "## Workflow" section (lines 34-66), Step 5 ("Invoke code-validator Agent") currently does not mention worktree context. Update the workflow step description to include worktree context passing:
+
+Replace Step 5 content:
+```
+│ 5. Invoke code-validator Agent                          │
+│    - Check PLAN checklist                               │
+│    - Verify TEST implementation                         │
+│    - Run quality checks (ruff/ty/pytest etc.)           │
+```
+
+With:
+```
+│ 5. Invoke code-validator Agent (single invocation)      │
+│    - Pass: worktree_path, coder namespace, phase_id     │
+│    - Pass: PLAN path, TEST path, GLOBAL path            │
+│    - Validator manages validate-fix loop internally     │
+│    - Validator returns final PASS/FAIL result           │
+```
+
+Also update Step 6 ("Validation Loop") to reflect the new pattern:
+
+Replace:
+```
+│ 6. Validation Loop                                      │
+│    - If fail: Coder fixes (max 3 attempts)              │
+│    - If still fail: skip and report                     │
+```
+
+With:
+```
+│ 6. Process Validator Result                             │
+│    - PASS: proceed to commit (code + documents)         │
+│    - FAIL: phase already marked SKIPPED by validator    │
+```
+
+### C6. Update "code all" Mode
+
+In the "`/dotclaude:code all` - Automatic Full Execution" section (lines 197-350), verify and update:
+
+**Step 6 (Error Handling, lines 236-239)**:
+The current text "On phase failure after 3 retries: mark SKIPPED" is correct in spirit but should clarify that retries happen inside the validator:
+
+Replace:
+```
+│ 6. Error Handling                                           │
+│    - On phase failure after 3 retries: mark SKIPPED         │
+│    - Continue to next phase (do NOT halt)                   │
+│    - Record all issues for final report                     │
+```
+
+With:
+```
+│ 6. Error Handling                                           │
+│    - Validator handles retries internally (max 3)           │
+│    - On validator FAIL: phase already marked SKIPPED        │
+│    - Continue to next phase (do NOT halt)                   │
+│    - Record validator report for final summary              │
+```
+
+**Step 7 (Auto-Commit, lines 241-243)**:
+Expand to include document files:
+
+Replace:
+```
+│ 7. Auto-Commit                                              │
+│    - Commit after each successful phase                     │
+│    - Message: feat({subject}): complete PHASE_{k}           │
+```
+
+With:
+```
+│ 7. Auto-Commit                                              │
+│    - Commit after each successful phase                     │
+│    - Include: code files + PLAN + GLOBAL + TEST documents   │
+│    - Message: feat({subject}): complete PHASE_{k}           │
+```
+
+### C7. Update Commit Pattern in Output Section
+
+In the "## Workflow" section, Step 7 ("On Success", lines 62-65):
+
+Replace:
+```
+│ 7. On Success                                           │
+│    - git add, commit (with user permission)             │
+│    - Report completion                                  │
+```
+
+With:
+```
+│ 7. On Success                                           │
+│    - git add (code files + PLAN + GLOBAL + TEST docs)   │
+│    - git commit (with user permission)                  │
+│    - Report completion                                  │
+```
+
+## Completion Checklist
+
+- [ ] C1: All coder namespace references in code.md use `dotclaude:coders:coder-{language}`
+- [ ] C1: Note added above Coder Selection table explaining Task tool namespace
+- [ ] C2: Validation Loop diagram updated to show validator-managed loop with single invocation
+- [ ] C3: Validation Requirements updated to include full context passing and document update verification
+- [ ] C4: Pre-Commit Checklist expanded to include PLAN, GLOBAL, TEST document files
+- [ ] C5: Workflow Step 5 updated with worktree context and coder namespace passing
+- [ ] C5: Workflow Step 6 updated to "Process Validator Result"
+- [ ] C6: "code all" error handling updated to reflect validator-internal retries
+- [ ] C6: "code all" auto-commit updated to include document files
+- [ ] C7: Workflow Step 7 updated to include document files in git add
+- [ ] No remaining references to orchestrator-managed retry loop in code.md
+- [ ] No remaining references to old coder namespace (dotclaude:coder-{lang} without coders:)
+
+## Notes
+
+- `code.md` is the standalone command (`/dotclaude:code`). It must be consistent with the orchestrator flow in `start-new.md` but is invoked independently.
+- The "code all" mode follows the same patterns as single-phase execution but iterates automatically.
+- Line numbers reference the current (unmodified) `code.md`. Use surrounding context to locate sections if lines have shifted.
+- The Coder Selection table (lines 153-159) uses file paths, not namespaces. The namespace note is added above the table for clarity.

--- a/claude_works/code-validate-loop/PHASE_2_PLAN_code-validate-loop.md
+++ b/claude_works/code-validate-loop/PHASE_2_PLAN_code-validate-loop.md
@@ -206,18 +206,18 @@ With:
 
 ## Completion Checklist
 
-- [ ] C1: All coder namespace references in code.md use `dotclaude:coders:coder-{language}`
-- [ ] C1: Note added above Coder Selection table explaining Task tool namespace
-- [ ] C2: Validation Loop diagram updated to show validator-managed loop with single invocation
-- [ ] C3: Validation Requirements updated to include full context passing and document update verification
-- [ ] C4: Pre-Commit Checklist expanded to include PLAN, GLOBAL, TEST document files
-- [ ] C5: Workflow Step 5 updated with worktree context and coder namespace passing
-- [ ] C5: Workflow Step 6 updated to "Process Validator Result"
-- [ ] C6: "code all" error handling updated to reflect validator-internal retries
-- [ ] C6: "code all" auto-commit updated to include document files
-- [ ] C7: Workflow Step 7 updated to include document files in git add
-- [ ] No remaining references to orchestrator-managed retry loop in code.md
-- [ ] No remaining references to old coder namespace (dotclaude:coder-{lang} without coders:)
+- [x] C1: All coder namespace references in code.md use `dotclaude:coders:coder-{language}`: Verified no `dotclaude:coder-` (without coders:) remains; correct namespace at code.md:168
+- [x] C1: Note added above Coder Selection table explaining Task tool namespace: Verified at code.md:168
+- [x] C2: Validation Loop diagram updated to show validator-managed loop with single invocation: Verified at code.md:83-109
+- [x] C3: Validation Requirements updated to include full context passing and document update verification: Verified at code.md:76-81
+- [x] C4: Pre-Commit Checklist expanded to include PLAN, GLOBAL, TEST document files: Verified at code.md:113-123
+- [x] C5: Workflow Step 5 updated with worktree context and coder namespace passing: Verified at code.md:53-57
+- [x] C5: Workflow Step 6 updated to "Process Validator Result": Verified at code.md:59-61
+- [x] C6: "code all" error handling updated to reflect validator-internal retries: Verified at code.md:253-257
+- [x] C6: "code all" auto-commit updated to include document files: Verified at code.md:259-262
+- [x] C7: Workflow Step 7 updated to include document files in git add: Verified at code.md:63-66
+- [x] No remaining references to orchestrator-managed retry loop in code.md: Verified via grep (0 matches)
+- [x] No remaining references to old coder namespace (dotclaude:coder-{lang} without coders:): Verified via grep (0 matches)
 
 ## Notes
 

--- a/claude_works/code-validate-loop/PHASE_2_TEST.md
+++ b/claude_works/code-validate-loop/PHASE_2_TEST.md
@@ -10,61 +10,61 @@ These test cases verify the correctness of changes to `commands/code.md`. Since 
 
 ### code.md: Coder Namespace Correction
 
-- [ ] TC-1.1: No occurrences of `dotclaude:coder-` (without `coders:`) remain in code.md
-- [ ] TC-1.2: All Task tool coder invocations use `dotclaude:coders:coder-{language}`
-- [ ] TC-1.3: Note above Coder Selection table explains Task tool namespace mapping: `dotclaude:coders:coder-{language}` maps to `agents/coders/{language}.md`
-- [ ] TC-1.4: Coder Selection table still lists correct file paths (coders/python.md, coders/javascript.md, etc.)
+- [x] TC-1.1: No occurrences of `dotclaude:coder-` (without `coders:`) remain in code.md
+- [x] TC-1.2: All Task tool coder invocations use `dotclaude:coders:coder-{language}`
+- [x] TC-1.3: Note above Coder Selection table explains Task tool namespace mapping: `dotclaude:coders:coder-{language}` maps to `agents/coders/{language}.md`
+- [x] TC-1.4: Coder Selection table still lists correct file paths (coders/python.md, coders/javascript.md, etc.)
 
 ### code.md: Validation Loop Diagram
 
-- [ ] TC-2.1: Validation Loop diagram shows single invocation of code-validator
-- [ ] TC-2.2: Diagram shows validator passing worktree_path, coder namespace, phase_id, document paths
-- [ ] TC-2.3: Diagram shows validator-internal loop (validate -> fail -> invoke coder -> re-validate, max 3)
-- [ ] TC-2.4: Diagram shows two final outcomes: PASS (documents updated) or FAIL (phase SKIPPED)
-- [ ] TC-2.5: Diagram shows orchestrator receiving final result and committing or skipping
-- [ ] TC-2.6: No references to orchestrator-managed retry logic remain in the diagram
+- [x] TC-2.1: Validation Loop diagram shows single invocation of code-validator
+- [x] TC-2.2: Diagram shows validator passing worktree_path, coder namespace, phase_id, document paths
+- [x] TC-2.3: Diagram shows validator-internal loop (validate -> fail -> invoke coder -> re-validate, max 3)
+- [x] TC-2.4: Diagram shows two final outcomes: PASS (documents updated) or FAIL (phase SKIPPED)
+- [x] TC-2.5: Diagram shows orchestrator receiving final result and committing or skipping
+- [x] TC-2.6: No references to orchestrator-managed retry logic remain in the diagram
 
 ### code.md: Mandatory Validation Section
 
-- [ ] TC-3.1: Validation Requirements include "invoke code-validator agent with full context"
-- [ ] TC-3.2: Validation Requirements state validator manages retries internally
-- [ ] TC-3.3: Validation Requirements include ensuring validator has updated documents before commit
-- [ ] TC-3.4: Validation Requirements include "include updated documents in the commit"
+- [x] TC-3.1: Validation Requirements include "invoke code-validator agent with full context"
+- [x] TC-3.2: Validation Requirements state validator manages retries internally
+- [x] TC-3.3: Validation Requirements include ensuring validator has updated documents before commit
+- [x] TC-3.4: Validation Requirements include "include updated documents in the commit"
 
 ### code.md: Pre-Commit Checklist
 
-- [ ] TC-4.1: Checklist includes `{working_directory}/{subject}/PHASE_{k}_PLAN_{keyword}.md` in git add
-- [ ] TC-4.2: Checklist includes `{working_directory}/{subject}/GLOBAL.md` in git add
-- [ ] TC-4.3: Checklist includes `{working_directory}/{subject}/PHASE_{k}_TEST.md` in git add
-- [ ] TC-4.4: Checklist still includes changed code files in git add
-- [ ] TC-4.5: Checklist mentions quality checks are auto-detected per project (not hardcoded)
+- [x] TC-4.1: Checklist includes `{working_directory}/{subject}/PHASE_{k}_PLAN_{keyword}.md` in git add
+- [x] TC-4.2: Checklist includes `{working_directory}/{subject}/GLOBAL.md` in git add
+- [x] TC-4.3: Checklist includes `{working_directory}/{subject}/PHASE_{k}_TEST.md` in git add
+- [x] TC-4.4: Checklist still includes changed code files in git add
+- [x] TC-4.5: Checklist mentions quality checks are auto-detected per project (not hardcoded)
 
 ### code.md: Workflow Steps Update
 
-- [ ] TC-5.1: Step 5 in workflow describes single invocation with full context
-- [ ] TC-5.2: Step 5 mentions passing worktree_path, coder namespace, document paths
-- [ ] TC-5.3: Step 6 renamed/updated to "Process Validator Result" (not "Validation Loop")
-- [ ] TC-5.4: Step 6 describes PASS (commit with documents) and FAIL (already SKIPPED) outcomes
-- [ ] TC-5.5: Step 7 includes document files in git add alongside code files
+- [x] TC-5.1: Step 5 in workflow describes single invocation with full context
+- [x] TC-5.2: Step 5 mentions passing worktree_path, coder namespace, document paths
+- [x] TC-5.3: Step 6 renamed/updated to "Process Validator Result" (not "Validation Loop")
+- [x] TC-5.4: Step 6 describes PASS (commit with documents) and FAIL (already SKIPPED) outcomes
+- [x] TC-5.5: Step 7 includes document files in git add alongside code files
 
 ### code.md: "code all" Mode Updates
 
-- [ ] TC-6.1: Error handling step clarifies retries happen inside the validator
-- [ ] TC-6.2: Error handling states "phase already marked SKIPPED" (by validator, not orchestrator)
-- [ ] TC-6.3: Auto-commit step includes document files (PLAN + GLOBAL + TEST)
-- [ ] TC-6.4: Auto-commit step still includes code files
+- [x] TC-6.1: Error handling step clarifies retries happen inside the validator
+- [x] TC-6.2: Error handling states "phase already marked SKIPPED" (by validator, not orchestrator)
+- [x] TC-6.3: Auto-commit step includes document files (PLAN + GLOBAL + TEST)
+- [x] TC-6.4: Auto-commit step still includes code files
 
 ## Integration Tests
 
-- [ ] IT-1: Validator invocation pattern in code.md matches the contract defined in code-validator.md Phase 1 (same parameters: worktree_path, coder_namespace, phase_id, plan_path, test_path, global_path)
-- [ ] IT-2: Coder namespace in code.md matches the corrected namespace in start-new.md (`dotclaude:coders:coder-{detected_language}`)
-- [ ] IT-3: Commit scope in code.md matches the commit scope in start-new.md (code + PLAN + GLOBAL + TEST)
-- [ ] IT-4: Validation loop pattern in code.md is consistent with the pattern in start-new.md (single-invocation, no orchestrator retry loop)
-- [ ] IT-5: "code all" mode validation pattern is consistent with single-phase execution pattern
+- [x] IT-1: Validator invocation pattern in code.md matches the contract defined in code-validator.md Phase 1 (same parameters: worktree_path, coder_namespace, phase_id, plan_path, test_path, global_path)
+- [x] IT-2: Coder namespace in code.md matches the corrected namespace in start-new.md (`dotclaude:coders:coder-{detected_language}`)
+- [x] IT-3: Commit scope in code.md matches the commit scope in start-new.md (code + PLAN + GLOBAL + TEST)
+- [x] IT-4: Validation loop pattern in code.md is consistent with the pattern in start-new.md (single-invocation, no orchestrator retry loop)
+- [x] IT-5: "code all" mode validation pattern is consistent with single-phase execution pattern
 
 ## Edge Cases
 
-- [ ] EC-1: Verify code.md handles the case where PHASE_{k}_TEST.md does not exist (git add should use conditional add or check existence)
-- [ ] EC-2: Verify "code all" mode documentation correctly describes behavior when a phase is SKIPPED (continues to next phase)
-- [ ] EC-3: Verify parallel phase execution in code.md passes worktree context to each phase's validator invocation
-- [ ] EC-4: Verify merge phase (PHASE_{k}.5) documentation is unaffected by these changes (merge phases do not use the validate-fix loop)
+- [x] EC-1: Verify code.md handles the case where PHASE_{k}_TEST.md does not exist (git add should use conditional add or check existence)
+- [x] EC-2: Verify "code all" mode documentation correctly describes behavior when a phase is SKIPPED (continues to next phase)
+- [x] EC-3: Verify parallel phase execution in code.md passes worktree context to each phase's validator invocation
+- [x] EC-4: Verify merge phase (PHASE_{k}.5) documentation is unaffected by these changes (merge phases do not use the validate-fix loop)

--- a/claude_works/code-validate-loop/PHASE_2_TEST.md
+++ b/claude_works/code-validate-loop/PHASE_2_TEST.md
@@ -1,0 +1,70 @@
+# Phase 2: Test Cases
+
+## Test Coverage Target
+
+>= 70%
+
+These test cases verify the correctness of changes to `commands/code.md`. Since all changes are to markdown instruction files, testing means structural verification and content correctness through inspection.
+
+## Unit Tests
+
+### code.md: Coder Namespace Correction
+
+- [ ] TC-1.1: No occurrences of `dotclaude:coder-` (without `coders:`) remain in code.md
+- [ ] TC-1.2: All Task tool coder invocations use `dotclaude:coders:coder-{language}`
+- [ ] TC-1.3: Note above Coder Selection table explains Task tool namespace mapping: `dotclaude:coders:coder-{language}` maps to `agents/coders/{language}.md`
+- [ ] TC-1.4: Coder Selection table still lists correct file paths (coders/python.md, coders/javascript.md, etc.)
+
+### code.md: Validation Loop Diagram
+
+- [ ] TC-2.1: Validation Loop diagram shows single invocation of code-validator
+- [ ] TC-2.2: Diagram shows validator passing worktree_path, coder namespace, phase_id, document paths
+- [ ] TC-2.3: Diagram shows validator-internal loop (validate -> fail -> invoke coder -> re-validate, max 3)
+- [ ] TC-2.4: Diagram shows two final outcomes: PASS (documents updated) or FAIL (phase SKIPPED)
+- [ ] TC-2.5: Diagram shows orchestrator receiving final result and committing or skipping
+- [ ] TC-2.6: No references to orchestrator-managed retry logic remain in the diagram
+
+### code.md: Mandatory Validation Section
+
+- [ ] TC-3.1: Validation Requirements include "invoke code-validator agent with full context"
+- [ ] TC-3.2: Validation Requirements state validator manages retries internally
+- [ ] TC-3.3: Validation Requirements include ensuring validator has updated documents before commit
+- [ ] TC-3.4: Validation Requirements include "include updated documents in the commit"
+
+### code.md: Pre-Commit Checklist
+
+- [ ] TC-4.1: Checklist includes `{working_directory}/{subject}/PHASE_{k}_PLAN_{keyword}.md` in git add
+- [ ] TC-4.2: Checklist includes `{working_directory}/{subject}/GLOBAL.md` in git add
+- [ ] TC-4.3: Checklist includes `{working_directory}/{subject}/PHASE_{k}_TEST.md` in git add
+- [ ] TC-4.4: Checklist still includes changed code files in git add
+- [ ] TC-4.5: Checklist mentions quality checks are auto-detected per project (not hardcoded)
+
+### code.md: Workflow Steps Update
+
+- [ ] TC-5.1: Step 5 in workflow describes single invocation with full context
+- [ ] TC-5.2: Step 5 mentions passing worktree_path, coder namespace, document paths
+- [ ] TC-5.3: Step 6 renamed/updated to "Process Validator Result" (not "Validation Loop")
+- [ ] TC-5.4: Step 6 describes PASS (commit with documents) and FAIL (already SKIPPED) outcomes
+- [ ] TC-5.5: Step 7 includes document files in git add alongside code files
+
+### code.md: "code all" Mode Updates
+
+- [ ] TC-6.1: Error handling step clarifies retries happen inside the validator
+- [ ] TC-6.2: Error handling states "phase already marked SKIPPED" (by validator, not orchestrator)
+- [ ] TC-6.3: Auto-commit step includes document files (PLAN + GLOBAL + TEST)
+- [ ] TC-6.4: Auto-commit step still includes code files
+
+## Integration Tests
+
+- [ ] IT-1: Validator invocation pattern in code.md matches the contract defined in code-validator.md Phase 1 (same parameters: worktree_path, coder_namespace, phase_id, plan_path, test_path, global_path)
+- [ ] IT-2: Coder namespace in code.md matches the corrected namespace in start-new.md (`dotclaude:coders:coder-{detected_language}`)
+- [ ] IT-3: Commit scope in code.md matches the commit scope in start-new.md (code + PLAN + GLOBAL + TEST)
+- [ ] IT-4: Validation loop pattern in code.md is consistent with the pattern in start-new.md (single-invocation, no orchestrator retry loop)
+- [ ] IT-5: "code all" mode validation pattern is consistent with single-phase execution pattern
+
+## Edge Cases
+
+- [ ] EC-1: Verify code.md handles the case where PHASE_{k}_TEST.md does not exist (git add should use conditional add or check existence)
+- [ ] EC-2: Verify "code all" mode documentation correctly describes behavior when a phase is SKIPPED (continues to next phase)
+- [ ] EC-3: Verify parallel phase execution in code.md passes worktree context to each phase's validator invocation
+- [ ] EC-4: Verify merge phase (PHASE_{k}.5) documentation is unaffected by these changes (merge phases do not use the validate-fix loop)

--- a/claude_works/code-validate-loop/SPEC.md
+++ b/claude_works/code-validate-loop/SPEC.md
@@ -1,0 +1,234 @@
+<!-- dotclaude-config
+working_directory: claude_works
+base_branch: main
+language: ko_KR
+worktree_path: ../dotclaude-bugfix-code-validate-loop
+-->
+
+# Code > Validate > Checklist > Commit Loop Fix - Specification
+
+**Source Issue**: https://github.com/U-lis/dotclaude/issues/57
+**Target Version**: 0.4.0
+**Severity**: Major (core functionality failure)
+
+## Overview
+
+The code > validate > checklist update > commit loop in the dotclaude workflow is non-functional. After the SPEC-based design phase completes correctly, the code implementation phase fails at multiple points: the coder agent does not wait for validator inspection, the validator does not update checklist documents, lint/format/test quality checks do not execute, and per-phase commits do not include updated documentation files. This bugfix restores the intended loop behavior where each phase undergoes a complete code > validate > document update > commit cycle.
+
+## Bug Description
+
+### Symptoms
+
+1. Coder completes coding but does not wait for validator inspection results
+2. code-validator does not update PHASE_{k}_PLAN.md checklist items
+3. code-validator does not update GLOBAL.md phase status
+4. Lint, format, and test quality checks do not execute during validation
+5. Per-phase commits only include code files, missing updated PLAN/GLOBAL/TEST documents
+6. The retry loop (coder fix -> re-validate) does not function
+
+### Reproduction
+
+1. Run `/dotclaude:start-new`
+2. Select any work type
+3. Complete SPEC and Design phases (these work correctly)
+4. Select scope that includes "Code" (e.g., "Design -> Code")
+5. Observe: validation loop does not execute properly during code phase
+
+## Root Cause Analysis
+
+### RC-1: Coder Agent Namespace Mismatch
+
+**Location**: `commands/start-new.md` lines 600, 639, 657
+
+**Current (incorrect)**:
+```
+subagent_type="dotclaude:coder-{detected_language}"
+```
+
+**Correct**:
+```
+subagent_type="dotclaude:coders:coder-{detected_language}"
+```
+
+**Evidence**: Coder agents reside in `agents/coders/*.md` (subdirectory), requiring the `coders:coder-{lang}` namespace path. The current flat namespace `coder-{lang}` does not resolve to any agent definition.
+
+**Impact**: Coder agent invocation may fail silently or map to wrong agent, causing the entire code phase to malfunction.
+
+### RC-2: Missing Orchestrator Mediation Logic
+
+**Location**: `commands/start-new.md` lines 748-762
+
+**Problem**: The retry loop between coder and validator is pseudo-code only. There is no concrete implementation for:
+- Passing validator feedback (error details, fix instructions) back to the coder
+- Handling the result handoff between coder and validator Task tool invocations
+- Determining whether to retry, skip, or commit based on validator output
+
+**Current pseudo-code**:
+```
+attempt = 0
+while attempt < 3:
+  coder_result = invoke_coder(phase_id)
+  validator_result = invoke_code_validator(phase_id)
+  if validator_result.status == "PASS":
+    commit_phase()
+    break
+  attempt += 1
+```
+
+This is not executable instruction -- it is abstract pseudo-code that agents cannot follow.
+
+### RC-3: Incomplete Commit Scope
+
+**Location**: `commands/start-new.md` lines 741-742
+
+**Current**: Only code files are committed:
+```bash
+git add {changed_files}
+git commit -m "feat/fix: implement phase {phase_id} - {brief_description}"
+```
+
+**Missing from commit**:
+- Updated `PHASE_{k}_PLAN_{keyword}.md` (checked checklist items)
+- Updated `GLOBAL.md` (phase status changes)
+- Updated `PHASE_{k}_TEST.md` (test results if applicable)
+
+### RC-4: Missing Project Quality Tool Detection
+
+**Location**: `agents/code-validator.md` lines 56-80
+
+**Problem**: Language-specific quality commands (ruff, eslint, cargo clippy, etc.) are listed statically but there is no mechanism to:
+- Detect which language/toolchain the current project uses
+- Determine if the listed commands are actually available in the project
+- Fall back gracefully when a command does not exist
+- Read project-specific quality tool configuration
+
+**User expectation**: "lint, format, test must work, and since each project is different, it should check the project settings and proceed accordingly."
+
+### RC-5: Incomplete code-validator Prompt in Orchestrator
+
+**Location**: `commands/start-new.md` lines 694-732
+
+**Problem**: The prompt sent to code-validator:
+- Asks for validation result report only (read-only inspection)
+- Does NOT instruct validator to update PLAN/GLOBAL documents
+- Does NOT provide worktree path context (validator cannot find files in worktree)
+- Does NOT instruct validator to invoke coder for fixes (validator has no loop authority)
+- Does NOT provide the coder agent namespace for fix delegation
+
+## Functional Requirements
+
+### FR-1: Fix Coder Agent Namespace
+
+- [ ] FR-1.1: Update all coder agent invocations in `commands/start-new.md` to use correct namespace `dotclaude:coders:coder-{detected_language}`
+- [ ] FR-1.2: Update coder agent references in `commands/code.md` to match the corrected namespace
+- [ ] FR-1.3: Verify namespace matches actual agent file locations in `agents/coders/` directory
+
+### FR-2: Implement Validator-Managed Loop
+
+The code-validator agent manages the entire validate-fix cycle internally (user decision: "validator self-loop" approach).
+
+- [ ] FR-2.1: code-validator receives full context from orchestrator in a single invocation (phase info, worktree path, coder agent namespace, document paths)
+- [ ] FR-2.2: code-validator executes validation checks (checklist verification, quality checks)
+- [ ] FR-2.3: On validation failure, code-validator invokes the appropriate coder agent via Task tool with specific fix instructions
+- [ ] FR-2.4: code-validator re-validates after coder fix (max 3 total attempts)
+- [ ] FR-2.5: On final success, code-validator updates PHASE_{k}_PLAN.md checklist, GLOBAL.md phase status, and PHASE_{k}_TEST.md
+- [ ] FR-2.6: code-validator returns final result (PASS/FAIL) with comprehensive report to orchestrator
+- [ ] FR-2.7: On 3x failure, code-validator marks phase as SKIPPED in GLOBAL.md and documents unresolved errors
+
+### FR-3: Expand Commit Scope
+
+- [ ] FR-3.1: Per-phase commits must include all changed code files
+- [ ] FR-3.2: Per-phase commits must include updated `PHASE_{k}_PLAN_{keyword}.md`
+- [ ] FR-3.3: Per-phase commits must include updated `GLOBAL.md`
+- [ ] FR-3.4: Per-phase commits must include updated `PHASE_{k}_TEST.md` (if modified)
+- [ ] FR-3.5: Commit message must reflect both code and document changes
+
+### FR-4: Implement Quality Tool Detection
+
+- [ ] FR-4.1: code-validator must detect available quality tools by inspecting project configuration files (package.json, pyproject.toml, Cargo.toml, etc.)
+- [ ] FR-4.2: code-validator must verify command availability before execution (check if tool binary exists)
+- [ ] FR-4.3: When a quality tool is not available, mark that check as N/A (do not fail validation)
+- [ ] FR-4.4: Quality check results must be included in the validation report
+- [ ] FR-4.5: Support detection for at minimum: Python (ruff, pytest), JavaScript/TypeScript (eslint, tsc, npm test), Rust (cargo clippy, cargo test), Svelte (eslint, svelte-check)
+
+### FR-5: Simplify Orchestrator Loop
+
+- [ ] FR-5.1: Orchestrator (`start-new.md`) invokes code-validator ONCE per phase with full context
+- [ ] FR-5.2: Orchestrator receives final result from code-validator (no intermediate retry management)
+- [ ] FR-5.3: Orchestrator commits all files (code + documents) based on validator result
+- [ ] FR-5.4: Orchestrator handles SKIP case (mark in GLOBAL.md, continue to next phase)
+
+### FR-6: Align code.md with New Pattern
+
+- [ ] FR-6.1: `commands/code.md` validation loop section must reference the validator-managed loop pattern
+- [ ] FR-6.2: `commands/code.md` must use corrected coder agent namespace
+- [ ] FR-6.3: `commands/code.md` commit scope must include document files
+- [ ] FR-6.4: `commands/code.md` must pass worktree path context to code-validator
+
+### FR-7: Provide Worktree Context to Validator
+
+- [ ] FR-7.1: Orchestrator must pass `worktree_path` to code-validator prompt
+- [ ] FR-7.2: code-validator must use worktree path to locate all files (code, PLAN, GLOBAL, TEST documents)
+- [ ] FR-7.3: code-validator must pass worktree path to coder when delegating fixes
+
+## Non-Functional Requirements
+
+- [ ] NFR-1: All changes are to `.md` instruction files only (no source code changes required)
+- [ ] NFR-2: Backward compatible with existing SPEC > Design > Code workflow sequence
+- [ ] NFR-3: Parallel phase execution (worktree isolation) must continue to function correctly
+- [ ] NFR-4: Maximum 3 retry attempts per phase (existing limit preserved)
+- [ ] NFR-5: Quality check graceful degradation -- missing tools must not block the entire validation
+- [ ] NFR-6: Document updates (PLAN, GLOBAL, TEST) must happen AFTER final coder completion to prevent overwrites during retry
+
+## Constraints
+
+- All changes are limited to `.md` instruction files (agents and commands)
+- Must maintain backward compatibility with existing SPEC > Design > Code workflow
+- Must not break parallel phase execution (worktree isolation pattern)
+- Quality tool commands must be auto-detected per project (not hardcoded assumptions)
+- The validator self-loop approach requires code-validator to use Task tool for coder invocation
+- Maximum retry limit of 3 attempts per phase must be preserved
+
+## Affected Files
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `commands/start-new.md` | Modify | Fix coder namespace (3 locations), enhance validator prompt, expand commit scope, simplify retry loop |
+| `agents/code-validator.md` | Modify | Implement validator-managed loop with coder invocation, add quality tool detection, enhance document update logic |
+| `commands/code.md` | Modify | Align validation loop with new pattern, fix coder namespace, expand commit scope |
+
+## Conflict Analysis
+
+| # | Existing Behavior | Required Behavior | Resolution |
+|---|-------------------|-------------------|------------|
+| 1 | code-validator retry logic assumes direct agent-to-agent communication (`send_fix_instructions`, `wait_for_coder_completion`) | code-validator invokes coder via Task tool with fix instructions | Rewrite retry logic in `agents/code-validator.md` to use explicit Task tool invocations |
+| 2 | `start-new.md` and `code.md` both implement their own validation workflow with different levels of detail | Single source of truth for loop logic owned by code-validator | Both `start-new.md` and `code.md` delegate loop management to code-validator; they only invoke validator once and handle the final result |
+
+## Edge Cases
+
+| # | Case | Expected Behavior |
+|---|------|-------------------|
+| 1 | Project has no test runner configured | Quality check for tests marked as N/A; validation proceeds with available checks only |
+| 2 | Coder creates files not listed in PLAN | Validator reports additional files in validation result; all changed files included in commit |
+| 3 | Validator updates GLOBAL.md then coder retry overwrites | Validator updates documents AFTER final coder completion only (FR-2.5, NFR-6) |
+| 4 | Parallel phases need different quality tools | Detect language/toolchain from each phase's PLAN document independently |
+| 5 | lint/test commands do not exist in project | Graceful skip with warning in validation report; do not fail validation |
+| 6 | 3x retry still fails | GLOBAL.md phase status marked as SKIPPED; errors documented in validation report; orchestrator continues to next phase |
+| 7 | code-validator selects wrong coder language | Detect language from PLAN document metadata or SPEC.md metadata; fall back to file extension analysis |
+| 8 | Worktree path not provided in validator prompt | code-validator defaults to current directory (`.`); logs warning about missing worktree context |
+
+## Out of Scope
+
+- Changes to `agents/designer.md` or `agents/technical-writer.md` agents
+- Changes to `commands/init-*.md` workflow files
+- New quality tool integrations beyond existing language support (Python, JS/TS, Rust, Svelte)
+- UI or user experience changes to the workflow
+- Changes to SPEC or Design phase behavior (these work correctly)
+- Addition of new configuration fields to `dotclaude-config.json` (quality tools are auto-detected)
+
+## Open Questions
+
+None. All design decisions have been resolved:
+- Validator self-loop approach confirmed by user
+- Quality tool detection via project file inspection (not configuration)
+- Document update timing: after final coder completion only

--- a/commands/code.md
+++ b/commands/code.md
@@ -50,17 +50,19 @@ User invokes `/dotclaude:code [phase]` where phase is like `1`, `2`, `3A`, `3.5`
 │    - Implement checklist items                          │
 │    - Create test cases                                  │
 ├─────────────────────────────────────────────────────────┤
-│ 5. Invoke code-validator Agent                          │
-│    - Check PLAN checklist                               │
-│    - Verify TEST implementation                         │
-│    - Run quality checks (ruff/ty/pytest etc.)           │
+│ 5. Invoke code-validator Agent (single invocation)      │
+│    - Pass: worktree_path, coder namespace, phase_id     │
+│    - Pass: PLAN path, TEST path, GLOBAL path            │
+│    - Validator manages validate-fix loop internally     │
+│    - Validator returns final PASS/FAIL result           │
 ├─────────────────────────────────────────────────────────┤
-│ 6. Validation Loop                                      │
-│    - If fail: Coder fixes (max 3 attempts)              │
-│    - If still fail: skip and report                     │
+│ 6. Process Validator Result                             │
+│    - PASS: proceed to commit (code + documents)         │
+│    - FAIL: phase already marked SKIPPED by validator    │
 ├─────────────────────────────────────────────────────────┤
 │ 7. On Success                                           │
-│    - git add, commit (with user permission)             │
+│    - git add (code files + PLAN + GLOBAL + TEST docs)   │
+│    - git commit (with user permission)                  │
 │    - Report completion                                  │
 └─────────────────────────────────────────────────────────┘
 ```
@@ -73,27 +75,36 @@ User invokes `/dotclaude:code [phase]` where phase is like `1`, `2`, `3A`, `3.5`
 
 After Coder completes implementation:
 
-1. **MUST** invoke code-validator agent
-2. **MUST** wait for validation result
-3. **MUST** ensure checklist updates are complete before commit
+1. **MUST** invoke code-validator agent with full context (worktree path, coder namespace, document paths)
+2. **MUST** wait for final validation result (validator manages retries internally)
+3. **MUST** ensure validator has updated PLAN checklist, GLOBAL status, and TEST results before commit
+4. **MUST** include updated documents in the commit (not just code files)
 
 ### Validation Loop
+
+The code-validator manages the entire validate-fix cycle internally.
+The orchestrator (this command) invokes the validator ONCE and receives the final result.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
 │ Coder completes implementation                          │
 │         ↓                                               │
-│ Invoke code-validator                                   │
+│ Invoke code-validator (SINGLE invocation)               │
+│   - Passes: worktree_path, coder namespace,             │
+│     phase_id, document paths                            │
 │         ↓                                               │
-│ Validation passed? ──NO──→ Coder fixes (attempt N/3)   │
-│         │                         ↓                     │
-│        YES                  Retry validation            │
-│         ↓                         │                     │
-│ code-validator updates:           │                     │
-│   - PHASE_{k}_PLAN.md checklist   │                     │
-│   - GLOBAL.md phase status        │                     │
-│         ↓                         │                     │
-│ Proceed to commit ←───────────────┘                     │
+│ code-validator internally:                              │
+│   ┌──────────────────────────────────────────────┐      │
+│   │ Validate → FAIL? → Invoke coder for fix      │      │
+│   │     ↑                    ↓                   │      │
+│   │     └──── Re-validate ←──┘ (max 3 attempts)  │      │
+│   └──────────────────────────────────────────────┘      │
+│         ↓                                               │
+│ code-validator returns final result:                    │
+│   - PASS: documents updated (PLAN, GLOBAL, TEST)        │
+│   - FAIL: phase marked SKIPPED in GLOBAL                │
+│         ↓                                               │
+│ Orchestrator commits or skips based on result           │
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -101,10 +112,14 @@ After Coder completes implementation:
 
 Before `git add` and `git commit`:
 
-- [ ] code-validator invoked and completed
-- [ ] All items in PHASE_{k}_PLAN.md checked off
-- [ ] GLOBAL.md phase status updated to "Complete"
-- [ ] Quality checks passed (linter, type check, tests)
+- [ ] code-validator invoked with full context and completed (final result received)
+- [ ] All items in PHASE_{k}_PLAN.md checked off (by validator)
+- [ ] GLOBAL.md phase status updated to "Complete" (by validator)
+- [ ] Quality checks passed or marked N/A (by validator, auto-detected per project)
+- [ ] git add includes: changed code files
+- [ ] git add includes: {working_directory}/{subject}/PHASE_{k}_PLAN_{keyword}.md
+- [ ] git add includes: {working_directory}/{subject}/GLOBAL.md
+- [ ] git add includes: {working_directory}/{subject}/PHASE_{k}_TEST.md (if modified)
 
 **DO NOT commit if any item above is unchecked.**
 
@@ -149,6 +164,8 @@ git worktree remove ../subject-3C
 ```
 
 ## Coder Selection
+
+Task tool namespace: `dotclaude:coders:coder-{language}` (maps to `agents/coders/{language}.md`)
 
 | Language/Framework | Agent |
 |-------------------|-------|
@@ -234,12 +251,14 @@ Execute all phases without user intervention.
 │ 5. Continue Until All Phases Complete                       │
 ├─────────────────────────────────────────────────────────────┤
 │ 6. Error Handling                                           │
-│    - On phase failure after 3 retries: mark SKIPPED         │
+│    - Validator handles retries internally (max 3)           │
+│    - On validator FAIL: phase already marked SKIPPED        │
 │    - Continue to next phase (do NOT halt)                   │
-│    - Record all issues for final report                     │
+│    - Record validator report for final summary              │
 ├─────────────────────────────────────────────────────────────┤
 │ 7. Auto-Commit                                              │
 │    - Commit after each successful phase                     │
+│    - Include: code files + PLAN + GLOBAL + TEST documents   │
 │    - Message: feat({subject}): complete PHASE_{k}           │
 ├─────────────────────────────────────────────────────────────┤
 │ 8. Generate Comprehensive Report                            │

--- a/commands/start-new.md
+++ b/commands/start-new.md
@@ -597,7 +597,7 @@ Collect Designer output and pass it to TechnicalWriter for document creation (St
 
 ```
 Task(
-  subagent_type="dotclaude:coder-{detected_language}",
+  subagent_type="dotclaude:coders:coder-{detected_language}",
   prompt="""
 ## Task: Implement Phase {phase_id}
 
@@ -636,7 +636,7 @@ Then invoke multiple Coder agents in a SINGLE message (parallel execution):
 ```
 # Call 1
 Task(
-  subagent_type="dotclaude:coder-{detected_language}",
+  subagent_type="dotclaude:coders:coder-{detected_language}",
   prompt="""
 ## Task: Implement Phase 3A (Parallel Branch)
 
@@ -654,7 +654,7 @@ PLAN path: claude_works/{subject}/PHASE_3A_PLAN_{keyword}.md
 
 # Call 2
 Task(
-  subagent_type="dotclaude:coder-{detected_language}",
+  subagent_type="dotclaude:coders:coder-{detected_language}",
   prompt="""
 ## Task: Implement Phase 3B (Parallel Branch)
 
@@ -692,41 +692,32 @@ git worktree remove ../{project_name}-{type}-{keyword}-3C
 Task(
   subagent_type="dotclaude:code-validator",
   prompt="""
-## Task: Validate Phase {phase_id} Implementation
+## Task: Validate and Fix Phase {phase_id} Implementation
 
-### Input
+### Context
+Worktree Path: {worktree_path}
+Coder Agent Namespace: dotclaude:coders:coder-{detected_language}
 Phase ID: {phase_id}
-PLAN path: claude_works/{subject}/PHASE_{phase_id}_PLAN_{keyword}.md
-(Read this file to extract the completion checklist)
 
-### Your Tasks
-1. Extract completion checklist from PLAN document
-2. Verify each checklist item:
-   - Files created/modified as specified
-   - Functionality implemented correctly
-   - Code follows project conventions
-3. Run quality checks:
-   - Build passes (if applicable)
-   - No linting errors
-   - No type errors (TypeScript projects)
-4. Report validation result: PASS or FAIL with details
+### Document Paths (relative to worktree)
+PLAN: {working_directory}/{subject}/PHASE_{phase_id}_PLAN_{keyword}.md
+TEST: {working_directory}/{subject}/PHASE_{phase_id}_TEST.md
+GLOBAL: {working_directory}/{subject}/GLOBAL.md
 
-### Output Format
-```yaml
-status: "PASS" | "FAIL"
-phase_id: "{phase_id}"
-checklist_results:
-  - item: "Checklist item description"
-    status: "COMPLETE" | "INCOMPLETE"
-    notes: "Details if incomplete"
-quality_checks:
-  build: "PASS" | "FAIL" | "N/A"
-  lint: "PASS" | "FAIL" | "N/A"
-  types: "PASS" | "FAIL" | "N/A"
-issues:
-  - "Description of any issues found"
-recommendation: "COMMIT" | "RETRY" | "SKIP"
-```
+### Your Authority
+You manage the ENTIRE validate-fix loop for this phase:
+1. Run validation (checklist + quality checks)
+2. If FAIL: invoke the coder agent (via Task tool using the namespace above) with fix instructions
+3. Re-validate after coder fix (max 3 total attempts)
+4. On final SUCCESS: update PLAN checklist, GLOBAL phase status, TEST results
+5. On 3x FAIL: mark phase as SKIPPED in GLOBAL, document unresolved errors
+
+### Important Rules
+- Use {worktree_path} to resolve ALL file paths
+- Pass {worktree_path} to the coder agent in fix prompts
+- Update documents ONLY after final successful validation (not during retries)
+- Auto-detect quality tools from project config files
+- Return final status: PASS or FAIL with comprehensive report
 
 Follow validation procedures from your agent definition.
 """
@@ -735,31 +726,21 @@ Follow validation procedures from your agent definition.
 
 **After code-validator Completes**:
 
-Based on validation result:
-- **PASS**: Commit the phase
+The code-validator manages the entire validate-fix cycle internally.
+The orchestrator receives only the final result.
+
+Based on the final validation result:
+- **PASS (recommendation: COMMIT)**: Commit the phase (all code files + updated documents)
   ```bash
-  git add {changed_files}
+  git add {changed_code_files}
+  git add {working_directory}/{subject}/PHASE_{phase_id}_PLAN_{keyword}.md
+  git add {working_directory}/{subject}/GLOBAL.md
+  git add {working_directory}/{subject}/PHASE_{phase_id}_TEST.md
   git commit -m "feat/fix: implement phase {phase_id} - {brief_description}"
   ```
-- **FAIL + retry_count < 3**: Call Coder again with feedback from validator
-- **FAIL + retry_count >= 3**: Mark phase as SKIPPED, record error, continue to next phase
+- **FAIL (recommendation: SKIP)**: Phase already marked as SKIPPED in GLOBAL.md by the validator. Record error and continue to next phase.
 
-**Retry Loop Pattern**:
-```
-attempt = 0
-while attempt < 3:
-  coder_result = invoke_coder(phase_id)
-  validator_result = invoke_code_validator(phase_id)
-  if validator_result.status == "PASS":
-    commit_phase()
-    break
-  attempt += 1
-
-if validator_result.status != "PASS":
-  mark_phase_skipped()
-  record_error(validator_result.issues)
-  # Continue to next phase
-```
+There is NO orchestrator-level retry loop. The validator handles all retries internally.
 
 ---
 
@@ -821,12 +802,12 @@ Parse GLOBAL.md Phase Overview table:
 # All execute simultaneously
 
 <Task tool call 1>
-  subagent_type: "dotclaude:coder-{detected_language}"
+  subagent_type: "dotclaude:coders:coder-{detected_language}"
   prompt: "Execute PHASE_3A in worktree ../{project_name}-{type}-{keyword}-3A"
 </Task tool call 1>
 
 <Task tool call 2>
-  subagent_type: "dotclaude:coder-{detected_language}"
+  subagent_type: "dotclaude:coders:coder-{detected_language}"
   prompt: "Execute PHASE_3B in worktree ../{project_name}-{type}-{keyword}-3B"
 </Task tool call 2>
 ```


### PR DESCRIPTION
## Summary

- code > validate > checklist > commit loop가 code implementation phase에서 정상 작동하지 않던 문제를 수정 (#57)
- coder 에이전트 네임스페이스 불일치 수정 (`dotclaude:coder-{lang}` → `dotclaude:coders:coder-{lang}`)
- code-validator가 자체적으로 validate-fix loop를 관리하도록 개선 (validator self-loop)
- per-phase commit에 PLAN/GLOBAL/TEST 문서 포함하도록 확장
- 프로젝트별 quality tool 자동 감지 (package.json, pyproject.toml, Cargo.toml 등)

## Changes

| File | Description |
|------|-------------|
| `agents/code-validator.md` | Context from Orchestrator 섹션 추가, Quality Tool Auto-Detection 구현, Validate-Fix Loop (Task tool coder 호출) 구현, Checklist Update Authority 강화 |
| `commands/start-new.md` | coder 네임스페이스 5곳 수정, validator 프롬프트 리라이트 (full context 전달), retry loop 단순화, commit 범위 확장 |
| `commands/code.md` | validator-managed loop 패턴 정렬, Pre-Commit Checklist 확장, Workflow Steps 업데이트, "code all" 모드 정렬 |

## Test plan

- [ ] `/dotclaude:start-new` → Design → Code 범위 실행 시 validate loop 정상 동작 확인
- [ ] Phase 완료 시 PLAN checklist 업데이트 확인
- [ ] Phase 완료 시 GLOBAL.md status 업데이트 확인
- [ ] Per-phase commit에 문서 파일 포함 확인
- [ ] Quality tool 미설치 프로젝트에서 N/A 처리 확인

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)