### PR TITLE
feat: version_file configure 시 자동 감지로 추천

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-02-25
+
+### Added
+
+- "Auto-detect and suggest" sub-action in `/dotclaude:configure` Setting 6 (Version Files) for automatic discovery of version files in the project
+  - Scans all 7 known version files from the `tagging.md` auto-detection table (`CHANGELOG.md`, `package.json`, `pyproject.toml`, `Cargo.toml`, `pom.xml`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`)
+  - Displays scan results in a table showing file name, detected version, regex pattern, and status (`New - can add`, `Already configured`, `Configured but missing`)
+  - Suggests adding newly discovered files that are not yet configured
+  - Suggests removing configured files that no longer exist on disk
+  - Follows existing Add/Remove workflow rules (empty-list auto-detect override warning, CHANGELOG.md mandatory and cannot be removed)
+  - Edge case handling: empty results message, all-configured notification
+- Design documentation for version-file-auto-detect feature (`claude_works/version-file-auto-detect/SPEC.md`, `claude_works/version-file-auto-detect/GLOBAL.md`, `claude_works/version-file-auto-detect/PHASE_1_PLAN_AUTO_DETECT_SUGGEST.md`)
+
 ## [0.3.1] - 2026-02-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Interactive workflow to edit settings at global or local scope. Changes take eff
 
 #### Version Files
 
-When `version_files` is empty (default), `/dotclaude:tagging` auto-detects common version files in the project (e.g., `package.json`, `pyproject.toml`, `Cargo.toml`, `.claude-plugin/plugin.json`). To override, configure explicit `{path, pattern}` entries where `pattern` is a regex with a capture group for the version string. `CHANGELOG.md` is always included regardless of configuration. Use `/dotclaude:configure` (Setting 6) to manage version files interactively.
+When `version_files` is empty (default), `/dotclaude:tagging` auto-detects common version files in the project (e.g., `package.json`, `pyproject.toml`, `Cargo.toml`, `.claude-plugin/plugin.json`). To override, configure explicit `{path, pattern}` entries where `pattern` is a regex with a capture group for the version string. `CHANGELOG.md` is always included regardless of configuration. Use `/dotclaude:configure` (Setting 6) to manage version files interactively -- the "Auto-detect and suggest" option scans the project for all 7 known version file types, shows their status, and lets you add or remove entries in one step.
 
 ## Commands & Core Workflow
 

--- a/claude_works/version-file-auto-detect/GLOBAL.md
+++ b/claude_works/version-file-auto-detect/GLOBAL.md
@@ -1,0 +1,57 @@
+# version_file configure 시 자동 감지로 추천 - Global Documentation
+
+## Feature Overview
+
+### Purpose
+`configure.md` Setting 6 (Version Files 관리)에 "Auto-detect and suggest" 서브 액션을 추가한다.
+
+### Problem
+현재 Setting 6에서 버전 파일을 추가하려면 사용자가 경로와 패턴을 수동으로 입력해야 한다. `tagging.md`에 이미 정의된 7개 알려진 파일의 자동 감지 테이블을 활용하지 않고 있으며, 설정된 파일이 디스크에서 사라진 경우를 감지하는 기능도 없다.
+
+### Solution
+Setting 6 메뉴에 "Auto-detect and suggest" 옵션을 추가하여, `tagging.md`의 자동 감지 테이블에 정의된 7개 파일을 프로젝트에서 스캔하고, 결과를 테이블로 표시한 뒤, 사용자가 추가/제거할 항목을 선택할 수 있도록 한다.
+
+## Architecture Decision
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| AD-1 | "Auto-detect and suggest" 옵션을 YAML options 배열의 5번째 위치에 추가 (Reset 다음, Skip 이전) | 기존 CRUD 옵션(View/Add/Remove/Reset) 뒤, 탈출 옵션(Skip) 앞에 배치하여 논리적 그룹핑 |
+| AD-2 | 자동 감지 테이블을 새 서브 액션 섹션에 인라인으로 정의하되, tagging.md를 정식 소스로 참조 | tagging.md와 이중 관리를 피하면서도 구현 지침을 명확하게 전달 |
+| AD-3 | 서브 액션을 3단계로 구조화: Scan -> Display -> Act | 단계별 분리로 로직을 명확하게 하고 엣지 케이스 처리를 용이하게 함 |
+| AD-4 | 파일 추가 시 기존 Add 워크플로우 규칙 재사용 (빈 리스트 경고, CHANGELOG.md 자동 추가) | 코드 일관성 유지 및 중복 로직 방지 |
+| AD-5 | 파일 제거 시 기존 Remove 워크플로우 규칙 재사용 (CHANGELOG.md 제거 불가) | 기존 제약 조건을 동일하게 적용 |
+| AD-6 | 완료 후 Setting 6 메뉴로 복귀 | 다른 서브 액션과 동일한 UX 패턴 |
+| AD-7 | Testing Checklist에 새 항목 추가 | 기존 테스트 체크리스트와 일관성 유지 |
+
+## Data Model
+
+변경 없음. 기존 `dotclaude-config.json`의 `version_files` 배열 구조를 그대로 사용한다.
+
+```json
+{
+  "version_files": [
+    { "path": "CHANGELOG.md", "pattern": "## \\[([^\\]]+)\\]" },
+    { "path": "package.json", "pattern": "\"version\":\\s*\"([^\"]+)\"" }
+  ]
+}
+```
+
+## Phase Overview
+
+| Phase | Description | Status | Dependencies |
+|-------|-------------|--------|--------------|
+| 1 | "Auto-detect and suggest" 서브 액션을 Setting 6에 추가 | pending | None |
+
+## File Structure
+
+### Modified Files
+
+| File | Change Description |
+|------|-------------------|
+| `commands/configure.md` | Setting 6에 "Auto-detect and suggest" 옵션 및 서브 액션 섹션 추가, Testing Checklist 항목 추가 |
+
+### Referenced Files (read-only)
+
+| File | Reference Purpose |
+|------|-------------------|
+| `commands/tagging.md` (line 51-97) | 자동 감지 테이블의 정식 소스 (7개 알려진 파일 및 패턴) |

--- a/claude_works/version-file-auto-detect/GLOBAL.md
+++ b/claude_works/version-file-auto-detect/GLOBAL.md
@@ -40,7 +40,7 @@ Setting 6 메뉴에 "Auto-detect and suggest" 옵션을 추가하여, `tagging.m
 
 | Phase | Description | Status | Dependencies |
 |-------|-------------|--------|--------------|
-| 1 | "Auto-detect and suggest" 서브 액션을 Setting 6에 추가 | pending | None |
+| 1 | "Auto-detect and suggest" 서브 액션을 Setting 6에 추가 | Complete | None |
 
 ## File Structure
 

--- a/claude_works/version-file-auto-detect/PHASE_1_PLAN_AUTO_DETECT_SUGGEST.md
+++ b/claude_works/version-file-auto-detect/PHASE_1_PLAN_AUTO_DETECT_SUGGEST.md
@@ -185,17 +185,17 @@ AskUserQuestion:
 
 ## Completion Checklist
 
-- [ ] 1.1: "Auto-detect and suggest" 옵션을 YAML options에 삽입 (Skip 앞)
-- [ ] 1.2: `##### Auto-detect and suggest Sub-action` 섹션 생성 (Reset 서브 액션 뒤)
-- [ ] 1.3: tagging.md의 7개 알려진 파일 참조하는 스캔 의사코드 정의
-- [ ] 1.4: 상태 분류 로직 정의 (New/Already configured/Configured but missing)
-- [ ] 1.5: 결과 테이블 형식 정의 (File, Detected Version, Pattern, Status 컬럼)
-- [ ] 1.6: 엣지 케이스 처리 정의 (파일 없음, 모두 설정됨)
-- [ ] 1.7: "추가할 파일 선택" 워크플로우 정의 (AskUserQuestion, Add 규칙 재사용)
-- [ ] 1.8: "사라진 파일 제거" 워크플로우 정의 (AskUserQuestion, Remove 규칙 재사용)
-- [ ] 1.9: Setting 6 메뉴 복귀 추가
-- [ ] 1.10: Testing Checklist에 자동 감지 관련 항목 추가
-- [ ] 1.11: 기존 서브 액션과 동일한 마크다운 서식 및 의사코드 스타일 확인
+- [x] 1.1: "Auto-detect and suggest" 옵션을 YAML options에 삽입 (Skip 앞) - Verified in configure.md:352
+- [x] 1.2: `##### Auto-detect and suggest Sub-action` 섹션 생성 (Reset 서브 액션 뒤) - Verified in configure.md:464
+- [x] 1.3: tagging.md의 7개 알려진 파일 참조하는 스캔 의사코드 정의 - Verified in configure.md:474-481 (all 7 patterns match tagging.md:55-63)
+- [x] 1.4: 상태 분류 로직 정의 (New/Already configured/Configured but missing) - Verified in configure.md:488-511
+- [x] 1.5: 결과 테이블 형식 정의 (File, Detected Version, Pattern, Status 컬럼) - Verified in configure.md:524-530
+- [x] 1.6: 엣지 케이스 처리 정의 (파일 없음, 모두 설정됨) - Verified in configure.md:518-521
+- [x] 1.7: "추가할 파일 선택" 워크플로우 정의 (AskUserQuestion, Add 규칙 재사용) - Verified in configure.md:536-552
+- [x] 1.8: "사라진 파일 제거" 워크플로우 정의 (AskUserQuestion, Remove 규칙 재사용) - Verified in configure.md:554-567
+- [x] 1.9: Setting 6 메뉴 복귀 추가 - Verified in configure.md:569-571
+- [x] 1.10: Testing Checklist에 자동 감지 관련 항목 추가 - Verified in configure.md:765-772 (8 items)
+- [x] 1.11: 기존 서브 액션과 동일한 마크다운 서식 및 의사코드 스타일 확인 - Verified: ##### header level, pseudocode blocks, bullet lists consistent
 
 ## Notes
 

--- a/claude_works/version-file-auto-detect/PHASE_1_PLAN_AUTO_DETECT_SUGGEST.md
+++ b/claude_works/version-file-auto-detect/PHASE_1_PLAN_AUTO_DETECT_SUGGEST.md
@@ -1,0 +1,205 @@
+# Phase 1: Auto-detect and suggest
+
+## Objective
+
+`commands/configure.md`의 Setting 6 (Version Files)에 "Auto-detect and suggest" 서브 액션을 추가한다. 이 서브 액션은 `tagging.md`의 자동 감지 테이블에 정의된 7개 파일을 프로젝트에서 스캔하고, 결과를 테이블로 표시하며, 사용자가 추가/제거할 항목을 선택할 수 있도록 한다.
+
+## Prerequisites
+
+- None (첫 번째이자 유일한 Phase)
+
+## Instructions
+
+수정 대상 파일: `commands/configure.md` (3개 위치)
+
+---
+
+### Change 1: YAML options 배열에 "Auto-detect and suggest" 옵션 삽입
+
+**위치**: `commands/configure.md` line 348-352 (Setting 6의 YAML options 배열)
+
+**현재 코드**:
+```yaml
+options:
+  - "View current version files"
+  - "Add a version file"
+  - "Remove a version file"
+  - "Reset to auto-detection"
+  - "Skip (no changes)"
+```
+
+**변경 내용**: `"Reset to auto-detection"` 다음, `"Skip (no changes)"` 이전에 새 옵션을 삽입한다.
+
+**변경 후 코드**:
+```yaml
+options:
+  - "View current version files"
+  - "Add a version file"
+  - "Remove a version file"
+  - "Reset to auto-detection"
+  - "Auto-detect and suggest"
+  - "Skip (no changes)"
+```
+
+---
+
+### Change 2: Auto-detect and suggest 서브 액션 섹션 추가
+
+**위치**: `commands/configure.md` line 461 이후 (Reset Sub-action 섹션의 `- Return to Setting 6 menu` 다음, `### Step 4: Save Configuration` 이전)
+
+**내용**: 아래의 새 섹션을 삽입한다. 기존 서브 액션(View/Add/Remove/Reset)과 동일한 마크다운 형식(##### 헤더, 불릿 리스트, 의사코드 블록)을 따른다.
+
+```markdown
+##### Auto-detect and suggest Sub-action
+
+이 서브 액션은 3단계로 수행된다: Scan -> Display -> Act
+
+**Step 1: Scan**
+
+`tagging.md`의 Auto-Detection 테이블에 정의된 7개 알려진 파일을 스캔한다 (참조: `commands/tagging.md` line 51-63).
+
+```bash
+# Known version files table (source of truth: tagging.md Auto-Detection table)
+KNOWN_FILES=(
+  "CHANGELOG.md|## \[([^\]]+)\]"
+  "package.json|\"version\":\s*\"([^\"]+)\""
+  "pyproject.toml|version\s*=\s*\"([^\"]+)\""
+  "Cargo.toml|version\s*=\s*\"([^\"]+)\""
+  "pom.xml|<version>([^<]+)</version>"
+  ".claude-plugin/plugin.json|\"version\":\s*\"([^\"]+)\""
+  ".claude-plugin/marketplace.json|\"version\":\s*\"([^\"]+)\""
+)
+
+# Load current version_files from config
+CONFIGURED_PATHS = [entry.path for entry in config.version_files]
+
+RESULTS = []
+for each (file, pattern) in KNOWN_FILES:
+    entry = { file: file, pattern: pattern, version: null, status: null }
+
+    if file exists in project root:
+        # Try to extract version using pattern
+        match = regex_search(read_file(file), pattern)
+        if match:
+            entry.version = match.group(1)
+        else:
+            entry.version = "extraction failed"
+
+        if file in CONFIGURED_PATHS:
+            entry.status = "Already configured"
+        else:
+            entry.status = "New - can add"
+    else:
+        if file in CONFIGURED_PATHS:
+            entry.status = "Configured but missing"
+            entry.version = "-"
+        else:
+            # File doesn't exist and not configured -> skip (don't show)
+            continue
+
+    RESULTS.append(entry)
+```
+
+**Step 2: Display**
+
+스캔 결과를 테이블 형태로 표시한다.
+
+엣지 케이스 처리:
+- RESULTS가 비어있는 경우 (알려진 파일이 프로젝트에 하나도 없고, 설정된 파일 중 사라진 것도 없는 경우): "No known version files detected in this project. Use 'Add a version file' to manually add one." 메시지를 출력하고 Setting 6 메뉴로 복귀한다.
+- 모든 항목이 "Already configured" 상태인 경우: 테이블을 표시한 후 "All detected version files are already configured. No new files to add." 메시지를 출력한다.
+
+결과 테이블 형식:
+
+```
+| File | Detected Version | Pattern | Status |
+|------|-----------------|---------|--------|
+| package.json | 1.2.3 | "version":\s*"([^"]+)" | New - can add |
+| CHANGELOG.md | 1.2.3 | ## \[([^\]]+)\] | Already configured |
+| pyproject.toml | - | version\s*=\s*"([^"]+)" | Configured but missing |
+```
+
+**Step 3: Act**
+
+스캔 결과에 따라 사용자에게 추가/제거를 제안한다.
+
+**3a. Add Prompt (New - can add 파일이 있는 경우)**:
+
+"New - can add" 상태 파일이 있으면 AskUserQuestion으로 추가할 파일 목록을 제시한다.
+
+```
+AskUserQuestion:
+  question: "Which files would you like to add to version_files?"
+  options:
+    - "<file1> (version: <detected_version>)"
+    - "<file2> (version: <detected_version>)"
+    - ...
+    - "None - skip adding"
+```
+
+사용자가 파일을 선택하면 해당 파일의 path와 pattern을 version_files에 추가한다. 이때 기존 Add 워크플로우의 규칙을 동일하게 적용한다:
+- 빈 리스트(자동 감지 모드)에서 첫 추가 시: "Note: Adding explicit version files will override auto-detection mode." 경고를 표시한다
+- CHANGELOG.md 항목이 version_files에 없으면 자동으로 추가한다 (path: "CHANGELOG.md", pattern: `## \[(\d+\.\d+\.\d+)\]`)
+
+**3b. Remove Prompt (Configured but missing 파일이 있는 경우)**:
+
+"Configured but missing" 상태 파일이 있으면 AskUserQuestion으로 제거를 제안한다.
+
+```
+AskUserQuestion:
+  question: "These configured files no longer exist on disk. Remove them from version_files?"
+  options:
+    - "Yes, remove missing files"
+    - "No, keep them"
+```
+
+사용자가 제거를 선택하면 해당 파일들을 version_files에서 제거한다. 이때 기존 Remove 서브 액션의 규칙을 동일하게 적용한다:
+- CHANGELOG.md는 제거할 수 없다 (디스크에 없더라도 설정에서 제거 불가)
+
+**Step 4: Return**
+
+- Setting 6 메뉴로 복귀한다 (다른 서브 액션과 동일한 패턴)
+```
+
+위 전체 내용을 하나의 `##### Auto-detect and suggest Sub-action` 섹션으로 삽입한다. 마크다운 헤더 레벨, 의사코드 스타일, 불릿 리스트 형식 등이 기존 서브 액션(View/Add/Remove/Reset)과 일관되도록 한다.
+
+---
+
+### Change 3: Testing Checklist에 새 항목 추가
+
+**위치**: `commands/configure.md` line 631 이후 (Testing Checklist 섹션, 기존 마지막 항목 `- [ ] Changes take effect immediately` 다음)
+
+**추가할 항목**:
+
+```markdown
+- [ ] Auto-detect scans all 7 known files from tagging.md
+- [ ] Detected files show correct version extraction
+- [ ] "New - can add" status shown for unregistered existing files
+- [ ] "Already configured" status shown for registered existing files
+- [ ] "Configured but missing" status shown for registered non-existing files
+- [ ] Adding from auto-detect applies Add workflow rules (empty list warning, CHANGELOG.md auto-append)
+- [ ] Removing missing files applies Remove rules (CHANGELOG.md cannot be removed)
+- [ ] No known files detected shows appropriate message
+```
+
+---
+
+## Completion Checklist
+
+- [ ] 1.1: "Auto-detect and suggest" 옵션을 YAML options에 삽입 (Skip 앞)
+- [ ] 1.2: `##### Auto-detect and suggest Sub-action` 섹션 생성 (Reset 서브 액션 뒤)
+- [ ] 1.3: tagging.md의 7개 알려진 파일 참조하는 스캔 의사코드 정의
+- [ ] 1.4: 상태 분류 로직 정의 (New/Already configured/Configured but missing)
+- [ ] 1.5: 결과 테이블 형식 정의 (File, Detected Version, Pattern, Status 컬럼)
+- [ ] 1.6: 엣지 케이스 처리 정의 (파일 없음, 모두 설정됨)
+- [ ] 1.7: "추가할 파일 선택" 워크플로우 정의 (AskUserQuestion, Add 규칙 재사용)
+- [ ] 1.8: "사라진 파일 제거" 워크플로우 정의 (AskUserQuestion, Remove 규칙 재사용)
+- [ ] 1.9: Setting 6 메뉴 복귀 추가
+- [ ] 1.10: Testing Checklist에 자동 감지 관련 항목 추가
+- [ ] 1.11: 기존 서브 액션과 동일한 마크다운 서식 및 의사코드 스타일 확인
+
+## Notes
+
+- `commands/configure.md` 파일만 수정한다. 다른 파일은 변경하지 않는다.
+- 의사코드 내 7개 파일과 패턴은 `commands/tagging.md` line 51-63의 Auto-Detection 테이블과 정확히 일치해야 한다. 향후 테이블이 변경되면 이 섹션도 함께 업데이트해야 한다.
+- 기존 서브 액션과 동일한 수준의 마크다운 헤더(`#####`)를 사용한다.
+- "Auto-detect and suggest"라는 영문 이름은 기존 옵션명("View current version files", "Add a version file" 등)과 스타일을 맞추기 위해 영문으로 유지한다.

--- a/claude_works/version-file-auto-detect/SPEC.md
+++ b/claude_works/version-file-auto-detect/SPEC.md
@@ -1,0 +1,117 @@
+<!-- dotclaude-config
+working_directory: claude_works
+base_branch: main
+language: ko_KR
+worktree_path: ../dotclaude-feature-version-file-auto-detect
+-->
+
+# version_file configure 시 자동 감지로 추천 - Specification
+
+- **Source Issue**: https://github.com/U-lis/dotclaude/issues/56
+- **Target Version**: 0.4.0
+- **Work Type**: feature
+
+## Overview
+
+### Goal
+`configure.md` Setting 6 (Version Files 관리)에 "자동 감지로 추천" 서브 액션을 추가하여, `tagging.md`에 정의된 자동 감지 테이블(7개 알려진 파일 + 패턴)을 활용해 프로젝트의 버전 파일을 자동으로 스캔하고 추천하는 기능을 구현한다.
+
+### Problem
+현재 `configure.md` Setting 6의 버전 파일 관리에서는 View/Add/Remove/Reset/Skip 서브 액션만 제공한다. 버전 파일을 추가하려면 사용자가 파일 경로와 패턴을 수동으로 입력해야 한다. `tagging.md`에는 이미 7개 알려진 버전 파일에 대한 자동 감지 테이블이 정의되어 있지만, `configure.md`의 Add 워크플로우에서는 이를 활용하지 않는다. 또한 설정된 파일이 디스크에서 사라진 경우 이를 감지하고 제거를 추천하는 기능이 없다.
+
+### Solution
+Setting 6 메뉴에 "자동 감지로 추천" 옵션을 추가한다. 이 옵션을 선택하면 `tagging.md`의 자동 감지 테이블에 정의된 7개 파일을 프로젝트에서 스캔하고, 결과를 테이블로 표시한 뒤, 사용자가 추가/제거할 항목을 선택할 수 있도록 한다.
+
+## Functional Requirements
+
+- [ ] **FR-1**: `configure.md` Setting 6에 "자동 감지로 추천" 서브 액션 추가
+  - 기존 옵션 목록 (View / Add / Remove / Reset / Skip) 에 "Auto-detect and suggest" 옵션을 추가한다
+  - Setting 6 question의 options 배열에 새 항목을 삽입한다
+
+- [ ] **FR-2**: `tagging.md`의 자동 감지 테이블(7개 알려진 파일)을 활용한 프로젝트 스캔
+  - 스캔 대상 파일과 패턴 (tagging.md Auto-Detection 테이블 참조):
+
+    | Priority | File | Pattern |
+    |----------|------|---------|
+    | 1 | `CHANGELOG.md` | `## \[([^\]]+)\]` |
+    | 2 | `package.json` | `"version":\s*"([^"]+)"` |
+    | 3 | `pyproject.toml` | `version\s*=\s*"([^"]+)"` |
+    | 4 | `Cargo.toml` | `version\s*=\s*"([^"]+)"` |
+    | 5 | `pom.xml` | `<version>([^<]+)</version>` |
+    | 6 | `.claude-plugin/plugin.json` | `"version":\s*"([^"]+)"` |
+    | 7 | `.claude-plugin/marketplace.json` | `"version":\s*"([^"]+)"` |
+
+  - 각 파일에 대해 프로젝트 루트에서 존재 여부를 확인한다
+  - 파일이 존재하면 정의된 패턴으로 버전 문자열 추출을 시도한다
+
+- [ ] **FR-3**: 스캔 결과를 테이블 형태로 표시
+  - 테이블 컬럼 구성:
+
+    | Column | Description |
+    |--------|-------------|
+    | 파일명 (File) | 버전 파일의 상대 경로 |
+    | 찾은 버전 (Detected Version) | 패턴 매칭으로 추출된 버전 문자열. 추출 실패 시 "추출 실패" 표시 |
+    | 패턴 (Pattern) | 해당 파일에 사용된 정규식 패턴 |
+    | 상태 (Status) | 아래 3가지 상태 중 하나 |
+
+  - 상태(Status) 값:
+    - **신규 추가 가능 (New - can add)**: 디스크에 존재하지만 현재 version_files 설정에 없는 파일
+    - **이미 설정됨 (Already configured)**: 디스크에 존재하고 현재 version_files 설정에도 있는 파일
+    - **설정됐으나 사라짐 (Configured but missing)**: 현재 version_files 설정에 있지만 디스크에 존재하지 않는 파일
+
+- [ ] **FR-4**: 사용자가 추가할 항목을 선택할 수 있는 인터페이스
+  - 스캔 결과 테이블을 표시한 후, "신규 추가 가능" 상태인 파일 목록을 AskUserQuestion으로 제시한다
+  - 사용자가 추가할 파일을 선택하면 해당 파일의 path와 pattern을 version_files 설정에 추가한다
+  - 추가 시 기존 Add 워크플로우의 규칙을 동일하게 적용한다:
+    - 빈 리스트(자동 감지 모드)에서 첫 추가 시 명시적 설정이 자동 감지를 오버라이드함을 경고한다
+    - CHANGELOG.md 항목이 없으면 자동으로 추가한다
+
+- [ ] **FR-5**: 설정된 파일 중 더 이상 존재하지 않는 파일 감지 및 제거 추천
+  - 현재 version_files 설정에 등록된 파일 중 디스크에 존재하지 않는 파일을 식별한다
+  - 해당 파일 목록을 "설정됐으나 사라짐" 상태로 테이블에 표시한다
+  - 제거 여부를 AskUserQuestion으로 확인한다
+  - CHANGELOG.md는 제거 불가 (기존 Remove 서브 액션의 규칙과 동일)
+
+## Non-Functional Requirements
+
+- [ ] **NFR-1**: `configure.md`의 기존 Setting 6 구조와 코드 스타일 일관성을 유지한다
+  - 기존 서브 액션(View/Add/Remove/Reset)과 동일한 문서 구조 및 형식을 따른다
+  - 기존 워크플로우(Add, Remove)의 규칙과 검증 로직을 재사용한다
+
+- [ ] **NFR-2**: 특별한 성능/보안 요구사항 없음
+
+## Constraints
+
+- **수정 대상 파일**: `commands/configure.md` 파일만 수정한다
+- **패턴 소스**: `tagging.md`의 자동 감지 테이블에 정의된 동일한 7개 파일 및 패턴을 사용한다 (중복 정의하지 않고 참조)
+- **CHANGELOG.md 필수 규칙**: CHANGELOG.md는 항상 필수이며 제거할 수 없다 (기존 규칙 유지)
+- **기존 코드 패턴 준수**: `configure.md` 내 기존 서브 액션들의 코드 패턴과 구조를 따른다
+
+## Out of Scope
+
+- 없음 (필수 기능만 구현)
+
+## Analysis Results
+
+### Related Code
+
+| # | File | Line | Relationship |
+|---|------|------|--------------|
+| 1 | `commands/configure.md` | 344-461 | Setting 6 현재 구현 - View/Add/Remove/Reset 서브 액션 정의 |
+| 2 | `commands/tagging.md` | 51-97 | 자동 감지 테이블 - 7개 알려진 파일과 패턴 정의 및 해결 의사코드 |
+| 3 | `commands/configure.md` | 366-367 | View 서브 액션에서 자동 감지 결과를 보여주는 기존 로직 |
+| 4 | `commands/configure.md` | 440-447 | Add 워크플로우 (현재 수동 입력만 지원) |
+
+### Conflicts Identified
+
+충돌 없음. 기존 서브 액션 목록에 새 옵션을 추가하는 형태이므로 기존 기능에 영향이 없다.
+
+### Edge Cases
+
+| # | Case | Expected Behavior |
+|---|------|-------------------|
+| 1 | 프로젝트에 알려진 버전 파일이 하나도 없는 경우 | 빈 테이블을 표시하고 "추천할 파일이 없습니다" 메시지를 출력한다 |
+| 2 | 모든 알려진 파일이 이미 명시적 설정에 있는 경우 | 테이블에 모두 "이미 설정됨" 상태로 표시하고 "추가할 새 파일이 없습니다" 메시지를 출력한다 |
+| 3 | 설정된 파일이 더 이상 디스크에 존재하지 않는 경우 | "설정됐으나 사라짐" 상태로 표시하고 제거 여부를 확인한다 |
+| 4 | 파일은 존재하지만 패턴이 매치되지 않는 경우 | "찾은 버전" 컬럼에 "추출 실패"를 표시하고 사용한 패턴을 함께 표시한다. 추가 선택은 여전히 가능하다 |
+| 5 | 혼합 상태 (일부 신규, 일부 설정됨, 일부 사라짐) | 모든 항목을 통합 테이블에 표시하고 상태(Status) 컬럼으로 구분한다 |

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -349,6 +349,7 @@ options:
   - "Add a version file"
   - "Remove a version file"
   - "Reset to auto-detection"
+  - "Auto-detect and suggest"
   - "Skip (no changes)"
 context: |
   Current value: <current_version_files or "auto-detect (no explicit config)">
@@ -458,7 +459,116 @@ validate_version_pattern() {
 
 - Clear version_files array (set to `[]`)
 - Confirm: "Version files reset to auto-detection mode"
-- Return to Setting 6 menu
+- Return to Setting 6 menu after reset
+
+##### Auto-detect and suggest Sub-action
+
+This sub-action is performed in 3 steps: Scan -> Display -> Act
+
+**Step 1: Scan**
+
+Scan the 7 known files defined in the `tagging.md` Auto-Detection table (reference: `commands/tagging.md` line 51-63).
+
+```bash
+# Known version files table (source of truth: tagging.md Auto-Detection table)
+KNOWN_FILES=(
+  "CHANGELOG.md|## \[([^\]]+)\]"
+  "package.json|\"version\":\s*\"([^\"]+)\""
+  "pyproject.toml|version\s*=\s*\"([^\"]+)\""
+  "Cargo.toml|version\s*=\s*\"([^\"]+)\""
+  "pom.xml|<version>([^<]+)</version>"
+  ".claude-plugin/plugin.json|\"version\":\s*\"([^\"]+)\""
+  ".claude-plugin/marketplace.json|\"version\":\s*\"([^\"]+)\""
+)
+
+# Load current version_files from config
+CONFIGURED_PATHS = [entry.path for entry in config.version_files]
+
+RESULTS = []
+for each (file, pattern) in KNOWN_FILES:
+    entry = { file: file, pattern: pattern, version: null, status: null }
+
+    if file exists in project root:
+        # Try to extract version using pattern
+        match = regex_search(read_file(file), pattern)
+        if match:
+            entry.version = match.group(1)
+        else:
+            entry.version = "extraction failed"
+
+        if file in CONFIGURED_PATHS:
+            entry.status = "Already configured"
+        else:
+            entry.status = "New - can add"
+    else:
+        if file in CONFIGURED_PATHS:
+            entry.status = "Configured but missing"
+            entry.version = "-"
+        else:
+            # File doesn't exist and not configured -> skip (don't show)
+            continue
+
+    RESULTS.append(entry)
+```
+
+**Step 2: Display**
+
+Display scan results in a table format.
+
+Edge case handling:
+- If RESULTS is empty (no known files exist in the project and no configured files are missing): Display "No known version files detected in this project. Use 'Add a version file' to manually add one." and return to Setting 6 menu.
+- If all entries have "Already configured" status: Display the table, then show "All detected version files are already configured. No new files to add."
+
+Results table format:
+
+```
+| File | Detected Version | Pattern | Status |
+|------|-----------------|---------|--------|
+| package.json | 1.2.3 | "version":\s*"([^"]+)" | New - can add |
+| CHANGELOG.md | 1.2.3 | ## \[([^\]]+)\] | Already configured |
+| pyproject.toml | - | version\s*=\s*"([^"]+)" | Configured but missing |
+```
+
+**Step 3: Act**
+
+Based on scan results, suggest additions/removals to the user.
+
+**3a. Add Prompt (when "New - can add" files exist)**:
+
+If there are files with "New - can add" status, present the list via AskUserQuestion:
+
+```
+AskUserQuestion:
+  question: "Which files would you like to add to version_files?"
+  options:
+    - "<file1> (version: <detected_version>)"
+    - "<file2> (version: <detected_version>)"
+    - ...
+    - "None - skip adding"
+```
+
+When the user selects files, add the corresponding path and pattern to version_files. Apply the same rules as the existing Add workflow:
+- When adding to an empty list (auto-detect mode): Show "Note: Adding explicit version files will override auto-detection mode." warning
+- If CHANGELOG.md entry is not in version_files, auto-append it (path: "CHANGELOG.md", pattern: `## \[(\d+\.\d+\.\d+)\]`)
+
+**3b. Remove Prompt (when "Configured but missing" files exist)**:
+
+If there are files with "Configured but missing" status, suggest removal via AskUserQuestion:
+
+```
+AskUserQuestion:
+  question: "These configured files no longer exist on disk. Remove them from version_files?"
+  options:
+    - "Yes, remove missing files"
+    - "No, keep them"
+```
+
+When the user selects removal, remove those files from version_files. Apply the same rules as the existing Remove sub-action:
+- CHANGELOG.md cannot be removed (even if missing from disk, it cannot be removed from config)
+
+**Step 4: Return**
+
+- Return to Setting 6 menu (same pattern as other sub-actions)
 
 ### Step 4: Save Configuration
 
@@ -652,3 +762,11 @@ The init-config.sh hook ensures global config always exists. This skill can assu
 - [ ] Configuration saved with correct JSON format
 - [ ] Boolean values saved as true/false (not "true"/"false")
 - [ ] Changes take effect immediately
+- [ ] Auto-detect scans all 7 known files from tagging.md
+- [ ] Detected files show correct version extraction
+- [ ] "New - can add" status shown for unregistered existing files
+- [ ] "Already configured" status shown for registered existing files
+- [ ] "Configured but missing" status shown for registered non-existing files
+- [ ] Adding from auto-detect applies Add workflow rules (empty list warning, CHANGELOG.md auto-append)
+- [ ] Removing missing files applies Remove rules (CHANGELOG.md cannot be removed)
+- [ ] No known files detected shows appropriate message


### PR DESCRIPTION
## Summary
- `configure.md` Setting 6 (Version Files)에 "Auto-detect and suggest" 서브 액션 추가
- `tagging.md`의 자동 감지 테이블(7개 알려진 파일)을 활용한 프로젝트 스캔
- 테이블 형태로 결과 표시: 파일명, 찾은 버전, 패턴, 상태(신규/기존/사라짐)
- 사용자가 추가/제거할 항목 선택 가능
- 기존 Add/Remove 워크플로우 규칙 재사용 (빈 리스트 경고, CHANGELOG.md 필수)

Closes #56

## Test plan
- [ ] `/dotclaude:configure`에서 Setting 6 진입 시 "Auto-detect and suggest" 옵션 노출 확인
- [ ] 자동 감지 스캔 시 7개 알려진 파일 정상 탐색 확인
- [ ] 신규 파일 발견 시 "New - can add" 상태 표시 확인
- [ ] 이미 설정된 파일에 "Already configured" 상태 표시 확인
- [ ] 디스크에서 사라진 파일에 "Configured but missing" 상태 표시 확인
- [ ] 신규 파일 추가 시 Add 워크플로우 규칙 적용 확인 (빈 리스트 경고, CHANGELOG.md 자동 추가)
- [ ] 사라진 파일 제거 시 Remove 규칙 적용 확인 (CHANGELOG.md 제거 불가)
- [ ] 알려진 파일이 없을 때 적절한 메시지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)