### PR TITLE
Add Alembic Migration Workflow to python coder agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-04-30
+
+### Added
+
+- `## Migration Workflow` section in python coder agent (`agents/coders/python.md`) defining the Alembic schema migration workflow ([#62](https://github.com/U-lis/dotclaude/issues/62))
+  - Autogenerate-First Principle: `alembic revision --autogenerate -m "..."` is the default starting command for all schema migrations
+  - Validation Checklist (3 Steps): verify intended changes are reflected, verify no unintended changes are missed, identify items requiring manual handling
+  - Manual Edits: references `agents/coders/sql.md` Migration Patterns (lines 125-151) for SQL-level patterns when manual revision edits are needed
+  - Local DB Verification: bidirectional verification with `alembic upgrade head` and `alembic downgrade -1` to confirm reversibility before commit
+
 ## [0.4.0] - 2026-03-04
 
 ### Added

--- a/agents/coders/python.md
+++ b/agents/coders/python.md
@@ -70,6 +70,77 @@ Before creating constants, confirm with user:
 | Database | PostgreSQL |
 | Async | asyncio, httpx |
 
+## Migration Workflow
+
+Alembic migration 작업의 주체는 python coder다. 모든 schema 변경은 다음 4단계 워크플로우를 따른다.
+
+### Autogenerate-First Principle
+
+Migration 생성 시 **항상 autogenerate를 기본 명령으로 사용한다.** 수동 작성은 autogenerate가 정확히 처리하지 못하는 경우(enum 타입 변경, type mismatch 등)에만 허용한다.
+
+```bash
+# 기본 명령: autogenerate로 migration 초안 생성
+alembic revision --autogenerate -m "add user email index"
+```
+
+- Use `--autogenerate` 옵션 없이 `alembic revision` 만 실행하지 않는다 (빈 template만 생성됨).
+- Autogenerate 결과는 그대로 commit하지 않는다 — 반드시 다음 Validation Checklist를 거친다.
+
+### Validation Checklist (3 Steps)
+
+Autogenerate가 생성한 migration 파일을 열어 다음 3단계를 순서대로 검증한다.
+
+1. **변경 의도 반영 검증**
+   변경하고자 한 모든 schema 변경이 generated migration의 `upgrade()` / `downgrade()` 안에 포함되었는지 확인한다. 누락된 변경이 있으면 model 정의를 다시 점검하고 autogenerate를 재실행한다.
+
+2. **의도하지 않은 변경 검증**
+   Autogenerate가 detect한 변경 중 의도하지 않은 항목이 포함되지 않았는지 확인한다. 대표적인 사례:
+   - 의도치 않은 column drop (예: model에서 임시로 주석 처리한 필드)
+   - 의도치 않은 index/constraint 변경
+   발견 시 해당 op 호출을 migration에서 제거한다.
+
+3. **수동 처리 필요 항목 식별**
+   Autogenerate가 정확히 처리하지 못하는 케이스를 식별하고 다음 단계(Manual Edits)로 넘긴다. 대표적인 사례:
+   - PostgreSQL ENUM 타입 추가/제거/변경
+   - Type mismatch (예: `String(255)` → `Text` 변환은 detect되나 실제 column type 변경 의도 명시적 검토 필요)
+   - Data migration (column 추가와 동시에 기존 row 값 채우기)이 필요한 경우
+
+### Manual Edits (Reference: sql.md)
+
+Validation 검증 3에서 식별된 항목은 python coder가 직접 migration 파일을 수정한다. **sql coder를 호출하지 않는다.**
+
+- 올바른 op 함수 문법은 `agents/coders/sql.md` Migration Patterns 섹션 (lines 125-151) 및 그 안의 Safe Migrations subsection (lines 143-151)을 참조한다.
+- `agents/coders/sql.md` 자체는 참조 전용이며 본 작업으로 수정하지 않는다.
+- 대표적인 수동 작성 케이스:
+  - Enum 타입 변경: `op.execute("ALTER TYPE ...")` 로 직접 SQL 실행
+  - NOT NULL column 추가: server_default 지정 후 alter_column으로 default 제거 (Safe Migrations 패턴)
+  - Data migration: `op.execute()` 로 UPDATE 문 실행 후 NOT NULL 적용
+
+### Local DB Verification
+
+Migration commit 전에 반드시 local DB에서 양방향 적용을 검증한다.
+
+**사전 조건**:
+- `DATABASE_URL` 환경변수가 local DB를 가리키도록 설정되어 있는지 확인한다.
+- `alembic.ini` 의 `sqlalchemy.url` 또는 `env.py` 의 DB 연결 설정이 local 환경에 맞춰져 있는지 확인한다.
+
+**검증 명령 시퀀스**:
+```bash
+# 단계 1: upgrade 적용
+alembic upgrade head
+
+# 단계 2: 적용 후 schema 상태 확인 (PostgreSQL 예시)
+psql "$DATABASE_URL" -c "\d <table_name>"
+alembic current
+
+# 단계 3: 양방향 검증 — downgrade 후 다시 upgrade
+alembic downgrade -1
+alembic upgrade head
+```
+
+- 단계 3의 양방향 검증은 `downgrade()` 함수 누락/오류를 사전에 발견하기 위한 필수 절차다.
+- 위 시퀀스가 모두 정상 종료되어야 commit 가능하다. 실패 시 migration 파일을 수정 후 재검증한다.
+
 ## Environment Variables
 
 ### Rules

--- a/claude_works/2026_04_30-python-coder-alembic-migration/GLOBAL.md
+++ b/claude_works/2026_04_30-python-coder-alembic-migration/GLOBAL.md
@@ -1,0 +1,50 @@
+# Python Coder - Alembic Migration Autogenerate 기본화 - 전역 설계
+
+## Feature Overview
+
+### 목적
+Python coder 에이전트의 `agents/coders/python.md` instruction에 Alembic migration 작업의 표준 워크플로우를 명시한다. autogenerate 우선 원칙, 3단계 검증, 수동 수정 시 참조 가이드, local DB 양방향 적용 검증까지 단일 섹션으로 통합한다.
+
+### 해결하는 문제
+- python coder가 migration 작성 시 autogenerate를 사용하지 않아 누락/오류 발생
+- autogenerate 결과 검증 절차 부재로 의도치 않은 변경이 commit됨
+- 수동 수정이 필요한 경우 참조할 자료 (sql.md Migration Patterns) 가 instruction에 명시되지 않음
+- migration이 local DB에서 실제 동작하는지 확인하지 않은 채 commit됨
+
+### 솔루션 개요
+`agents/coders/python.md` 의 Preferred Stack 표(L72)와 Environment Variables(L73) 사이에 `## Migration Workflow` 섹션을 신설한다. 4개 하위 섹션이 SPEC의 FR-1 ~ FR-4에 1:1 매핑된다.
+
+## Architecture Decisions
+
+| ID | 결정 | 근거 |
+|----|------|------|
+| AD-1 | `## Migration Workflow` 섹션을 L72(Preferred Stack 표 끝)와 L73(`## Environment Variables`) 사이에 삽입 | Alembic이 Preferred Stack에 명시된 직후 워크플로우를 설명하는 것이 자연스러움. 기존 섹션 순서(Stack -> Workflow -> Env -> Testing)를 깨지 않음 |
+| AD-2 | 4개 하위 섹션을 FR-1 ~ FR-4 와 1:1 매핑 (`### Autogenerate-First Principle`, `### Validation Checklist (3 Steps)`, `### Manual Edits (Reference: sql.md)`, `### Local DB Verification`) | SPEC 검증 가능성 확보. 각 FR이 하나의 하위 섹션과 직결됨 |
+| AD-3 | sql.md 참조는 `agents/coders/sql.md` (Migration Patterns section, lines 125-151) 형식으로 명시 | 다른 coder agent가 `coders/_base.md` 를 참조하는 패턴과 일관. 정확한 line range로 ambiguity 제거 |
+| AD-4 | 명령형(imperative) instruction 톤 사용 ("Use", "Run", "Verify") | 기존 python.md/sql.md 의 instruction 톤과 일관 (예: L131 "Run before completion") |
+| AD-5 | bash code block + 주석으로 명령어 시퀀스 제시 | sql.md L210-222 Quality Checks 섹션과 동일 형식 |
+| AD-6 | Edge case는 별도 섹션 없이 Validation Checklist / Local DB Verification 안에 inline 흡수 | SIMPLE 복잡도 유지. instruction 가독성 향상 |
+
+## Data Model
+
+해당 사항 없음 (instruction 문서 변경 작업, schema/data 변경 없음).
+
+## Phase Overview
+
+| Phase | 설명 | Status | 선행조건 |
+|-------|------|--------|----------|
+| 1 | `agents/coders/python.md` 에 `## Migration Workflow` 섹션 (4개 하위 섹션 포함) 추가 | Pending | SPEC.md 승인 완료 |
+
+## File Structure
+
+| 파일 | 변경 유형 | 비고 |
+|------|-----------|------|
+| `agents/coders/python.md` | 수정 (섹션 추가) | L72와 L73 사이에 `## Migration Workflow` 섹션 삽입. 기존 내용은 유지 |
+| `agents/coders/sql.md` | 변경 없음 (참조 대상) | L125-151 Migration Patterns 섹션을 python.md에서 참조. 본 작업에서 수정 금지 |
+
+## Cross-File Reference Map
+
+| Source | Target | 목적 |
+|--------|--------|------|
+| `agents/coders/python.md` (신설 `### Manual Edits` 섹션) | `agents/coders/sql.md` L125-151 (Migration Patterns) | autogenerate가 처리하지 못하는 수동 수정 시 문법 참조 |
+| `agents/coders/python.md` (신설 `### Manual Edits` 섹션) | `agents/coders/sql.md` L143-151 (Safe Migrations) | NOT NULL column 추가 등 안전한 migration 패턴 참조 |

--- a/claude_works/2026_04_30-python-coder-alembic-migration/GLOBAL.md
+++ b/claude_works/2026_04_30-python-coder-alembic-migration/GLOBAL.md
@@ -33,7 +33,7 @@ Python coder 에이전트의 `agents/coders/python.md` instruction에 Alembic mi
 
 | Phase | 설명 | Status | 선행조건 |
 |-------|------|--------|----------|
-| 1 | `agents/coders/python.md` 에 `## Migration Workflow` 섹션 (4개 하위 섹션 포함) 추가 | Pending | SPEC.md 승인 완료 |
+| 1 | `agents/coders/python.md` 에 `## Migration Workflow` 섹션 (4개 하위 섹션 포함) 추가 | Complete | SPEC.md 승인 완료 |
 
 ## File Structure
 

--- a/claude_works/2026_04_30-python-coder-alembic-migration/PHASE_1_PLAN_alembic-migration.md
+++ b/claude_works/2026_04_30-python-coder-alembic-migration/PHASE_1_PLAN_alembic-migration.md
@@ -107,13 +107,13 @@ See `agents/coders/sql.md` Migration Patterns section (lines 125-151) and Safe M
 
 ## Completion Checklist / 완료 체크리스트
 
-- [ ] **C-1**: `agents/coders/python.md` L72와 L73 사이에 `## Migration Workflow` 헤더 삽입 (이전/이후 섹션 경계 유지 확인)
-- [ ] **C-2**: `### Autogenerate-First Principle` 작성 완료 (FR-1 만족)
-- [ ] **C-3**: `### Validation Checklist (3 Steps)` 작성 완료 (FR-2 만족, EC-1/EC-3 흡수)
-- [ ] **C-4**: `### Manual Edits (Reference: sql.md)` 작성 완료 (FR-3 만족, EC-2 흡수, sql.md L125-151 참조 표기 정확)
-- [ ] **C-5**: `### Local DB Verification` 작성 완료 (FR-4 만족, EC-4/EC-5 흡수)
-- [ ] **C-6**: markdown 구조 수동 점검 - heading hierarchy (`##` -> `###`), code fence 닫힘, table 정렬, 빈 줄 spacing
-- [ ] **C-7**: 다른 coder agent (`agents/coders/sql.md`, 기존 `agents/coders/python.md` 의 다른 섹션) 와 톤/형식 일관성 셀프 리뷰
+- [x] **C-1**: `agents/coders/python.md` L72와 L73 사이에 `## Migration Workflow` 헤더 삽입 (이전/이후 섹션 경계 유지 확인) — verified at python.md:73
+- [x] **C-2**: `### Autogenerate-First Principle` 작성 완료 (FR-1 만족) — verified at python.md:77-87
+- [x] **C-3**: `### Validation Checklist (3 Steps)` 작성 완료 (FR-2 만족, EC-1/EC-3 흡수) — verified at python.md:89-106
+- [x] **C-4**: `### Manual Edits (Reference: sql.md)` 작성 완료 (FR-3 만족, EC-2 흡수, sql.md L125-151 참조 표기 정확) — verified at python.md:108-117
+- [x] **C-5**: `### Local DB Verification` 작성 완료 (FR-4 만족, EC-4/EC-5 흡수) — verified at python.md:119-142
+- [x] **C-6**: markdown 구조 수동 점검 - heading hierarchy (`##` -> `###`), code fence 닫힘, table 정렬, 빈 줄 spacing — 4 fences in section (even), 1 `##` + 4 `###`, no level skip
+- [x] **C-7**: 다른 coder agent (`agents/coders/sql.md`, 기존 `agents/coders/python.md` 의 다른 섹션) 와 톤/형식 일관성 셀프 리뷰 — 명령형 톤("사용한다", "확인한다"), bash 주석 형식 일관
 
 ## Edge Case Mapping / 엣지 케이스 흡수 매핑
 
@@ -145,10 +145,10 @@ See `agents/coders/sql.md` Migration Patterns section (lines 125-151) and Safe M
 
 ## Definition of Done / 완료 기준
 
-- [ ] C-1 ~ C-7 체크리스트 모두 통과
-- [ ] `PHASE_1_TEST.md` 의 Manual Review Checklist 및 Structural Lint 모두 통과
-- [ ] `agents/coders/sql.md` 가 본 작업으로 인해 변경되지 않음 (`git diff agents/coders/sql.md` 가 empty)
-- [ ] `agents/coders/python.md` 의 기존 섹션(L1-72, 기존 L73 이후) 내용이 변경되지 않고 유지됨
+- [x] C-1 ~ C-7 체크리스트 모두 통과
+- [x] `PHASE_1_TEST.md` 의 Manual Review Checklist 및 Structural Lint 모두 통과
+- [x] `agents/coders/sql.md` 가 본 작업으로 인해 변경되지 않음 (`git diff agents/coders/sql.md` 가 empty)
+- [x] `agents/coders/python.md` 의 기존 섹션(L1-72, 기존 L73 이후) 내용이 변경되지 않고 유지됨 — 0 deletions in diff
 
 ## Notes / 특이사항
 

--- a/claude_works/2026_04_30-python-coder-alembic-migration/PHASE_1_PLAN_alembic-migration.md
+++ b/claude_works/2026_04_30-python-coder-alembic-migration/PHASE_1_PLAN_alembic-migration.md
@@ -1,0 +1,158 @@
+# Phase 1: Alembic Migration Workflow 섹션 추가
+
+## Objective / 목표
+
+`agents/coders/python.md` 에 Alembic migration 작업의 표준 워크플로우를 정의한 `## Migration Workflow` 섹션을 신설하여 SPEC의 FR-1 ~ FR-4 모두를 만족시킨다.
+
+## Prerequisites / 선행 조건
+
+- [x] SPEC.md 승인 완료
+- [x] GLOBAL.md 작성 완료
+- [x] 수정 대상 파일 (`agents/coders/python.md`) 및 참조 대상 파일 (`agents/coders/sql.md`) 의 현재 line 구조 확인 완료
+
+## Target File / 대상 파일
+
+| 항목 | 값 |
+|------|-----|
+| 파일 경로 | `agents/coders/python.md` |
+| 삽입 위치 | L72 (Preferred Stack 표 마지막 행) 와 L73 (`## Environment Variables` 헤더) 사이 |
+| 새 섹션 헤더 | `## Migration Workflow` |
+| 하위 섹션 수 | 4개 |
+| 영향받는 기존 line | 없음 (순수 삽입, 기존 line 수정/삭제 없음) |
+
+## Section Layout / 섹션 구조
+
+신설 섹션의 최상위 구조는 다음과 같다.
+
+```
+## Migration Workflow
+
+### Autogenerate-First Principle      <- FR-1 매핑
+### Validation Checklist (3 Steps)    <- FR-2 매핑
+### Manual Edits (Reference: sql.md)  <- FR-3 매핑
+### Local DB Verification             <- FR-4 매핑
+```
+
+## Instructions / 작성 가이드
+
+### 공통 작성 원칙
+
+1. 명령형 톤 사용 ("Use", "Run", "Verify", "Check")
+2. bash code block + 주석은 `agents/coders/sql.md` L210-222 형식 (`# 주석` -> `명령어`)
+3. 헤더 레벨: `##` (섹션) -> `###` (하위 섹션) -> `####` (필요 시만)
+4. 모든 외부 파일 참조는 절대 path + line range 명시 (예: `agents/coders/sql.md:125-151`)
+
+### Sub-section 1: `### Autogenerate-First Principle` (FR-1 매핑)
+
+**작성 내용**:
+- migration 작업의 기본 명령어로 `alembic revision --autogenerate -m "..."` 를 명시
+- autogenerate가 표준 워크플로우이며, 수동 작성은 autogenerate가 처리할 수 없는 경우(enum 변경 등)에만 허용한다는 원칙 진술
+- 명령어 예시 1개를 bash code block으로 제공
+
+**예상 길이**: 5-8 줄 본문 + bash block 3-5 줄
+
+**금지 사항**:
+- "should", "may", "might" 같은 약한 표현 사용 금지 -> "Use", "Always" 사용
+- autogenerate 가 만능이라는 인상 금지 (수동 수정 필요 케이스가 존재함을 명시)
+
+### Sub-section 2: `### Validation Checklist (3 Steps)` (FR-2 매핑)
+
+**작성 내용**:
+SPEC FR-2 의 3단계를 그대로 옮긴 numbered list (1, 2, 3) 작성.
+
+| # | 검증 항목 | 핵심 질문 |
+|---|----------|----------|
+| 1 | 변경 의도 반영 검증 | 변경하고자 한 모든 schema 변경이 generated migration에 포함되었는가? |
+| 2 | 의도하지 않은 변경 검증 | autogenerate가 detect한 변경 중 의도하지 않은 것 (예: column drop, 잘못된 type 추론) 이 포함되지 않았는가? |
+| 3 | 수동 처리 필요 항목 식별 | enum 변경, type mismatch (String <-> Text 등), data migration 필요 항목 등 autogenerate가 정확히 처리 못하는 케이스가 있는가? |
+
+**Edge case 흡수**:
+- EC-1 (의도치 않은 column drop) -> 검증 2 의 명시적 예시
+- EC-3 (Type mismatch) -> 검증 3 의 예시
+
+**예상 길이**: 8-12 줄 (각 검증 항목당 2-4 줄)
+
+### Sub-section 3: `### Manual Edits (Reference: sql.md)` (FR-3 매핑)
+
+**작성 내용**:
+- 검증 단계에서 수동 수정 필요 항목 발견 시, `agents/coders/sql.md` 의 Migration Patterns (L125-151) 를 참조하여 올바른 문법으로 직접 수정한다는 절차 명시
+- sql coder를 호출하지 않음을 명시 (작업 주체는 python coder)
+- sql.md를 수정하지 않음을 명시 (참조 전용)
+- enum 변경, NOT NULL column 추가 등 대표적 수동 수정 케이스를 짧게 나열
+
+**Edge case 흡수**:
+- EC-2 (Enum 변경) -> 대표 수동 수정 케이스로 명시
+
+**예상 길이**: 6-10 줄
+
+**참조 표기 형식 (정확히 사용)**:
+```
+See `agents/coders/sql.md` Migration Patterns section (lines 125-151) and Safe Migrations subsection (lines 143-151).
+```
+
+### Sub-section 4: `### Local DB Verification` (FR-4 매핑)
+
+**작성 내용**:
+- 사전 조건: `DATABASE_URL` 환경변수 및 `alembic.ini` 설정 확인
+- 단계 1: `alembic upgrade head` 정상 적용 확인
+- 단계 2: `alembic downgrade -1` -> `alembic upgrade head` 양방향 동작 검증
+- 단계 3: 적용 후 schema 상태 확인 (예: `\d <table>` in pgcli, 또는 `alembic current`)
+- 명령어 시퀀스를 bash code block + 주석으로 제공
+
+**Edge case 흡수**:
+- EC-4 (downgrade 실패) -> 양방향 검증 단계가 사전 발견 메커니즘
+- EC-5 (Local DB 미설치) -> 사전 조건 명시
+
+**예상 길이**: bash block 8-12 줄 + 본문 4-6 줄
+
+## Completion Checklist / 완료 체크리스트
+
+- [ ] **C-1**: `agents/coders/python.md` L72와 L73 사이에 `## Migration Workflow` 헤더 삽입 (이전/이후 섹션 경계 유지 확인)
+- [ ] **C-2**: `### Autogenerate-First Principle` 작성 완료 (FR-1 만족)
+- [ ] **C-3**: `### Validation Checklist (3 Steps)` 작성 완료 (FR-2 만족, EC-1/EC-3 흡수)
+- [ ] **C-4**: `### Manual Edits (Reference: sql.md)` 작성 완료 (FR-3 만족, EC-2 흡수, sql.md L125-151 참조 표기 정확)
+- [ ] **C-5**: `### Local DB Verification` 작성 완료 (FR-4 만족, EC-4/EC-5 흡수)
+- [ ] **C-6**: markdown 구조 수동 점검 - heading hierarchy (`##` -> `###`), code fence 닫힘, table 정렬, 빈 줄 spacing
+- [ ] **C-7**: 다른 coder agent (`agents/coders/sql.md`, 기존 `agents/coders/python.md` 의 다른 섹션) 와 톤/형식 일관성 셀프 리뷰
+
+## Edge Case Mapping / 엣지 케이스 흡수 매핑
+
+| Edge Case | SPEC 위치 | 흡수 위치 | 흡수 방법 |
+|-----------|-----------|----------|----------|
+| EC-1 (의도치 않은 column drop) | SPEC L93 | `### Validation Checklist` 검증 2 | 명시적 예시로 언급 |
+| EC-2 (Enum 변경) | SPEC L94 | `### Validation Checklist` 검증 3 + `### Manual Edits` | 대표 수동 수정 케이스로 양쪽에 언급 |
+| EC-3 (Type mismatch) | SPEC L95 | `### Validation Checklist` 검증 3 | 명시적 예시 (String -> Text) |
+| EC-4 (downgrade 실패) | SPEC L96 | `### Local DB Verification` 단계 2 | `downgrade -1 -> upgrade head` 양방향 시퀀스로 사전 발견 |
+| EC-5 (Local DB 미설치) | SPEC L97 | `### Local DB Verification` 사전 조건 | `DATABASE_URL`, `alembic.ini` 확인 단계 명시 |
+
+## Verification / 검증 방법
+
+본 phase는 instruction 문서 변경이므로 자동화된 unit/integration test가 없다. 검증은 다음 두 축으로 수행한다.
+
+### 1. 사람 리뷰 (Manual Review)
+- C-1 ~ C-7 체크리스트 모두 통과
+- SPEC FR-1 ~ FR-4 모두 신설 섹션에서 만족됨
+- 모든 Edge Case (EC-1 ~ EC-5) 가 mapping table에 따라 흡수됨
+
+### 2. 구조 검증 (Structural Lint)
+- markdown heading hierarchy 무결성 (`##` -> `###` 누락/역전 없음)
+- code fence 모두 닫힘 (` ``` ` 짝수 개)
+- 외부 파일 참조 line range 정확성:
+  - `agents/coders/sql.md:125-151` 가 실제 Migration Patterns 섹션과 일치
+  - `agents/coders/sql.md:143-151` 가 실제 Safe Migrations subsection과 일치
+
+자세한 검증 절차는 `PHASE_1_TEST.md` 참조.
+
+## Definition of Done / 완료 기준
+
+- [ ] C-1 ~ C-7 체크리스트 모두 통과
+- [ ] `PHASE_1_TEST.md` 의 Manual Review Checklist 및 Structural Lint 모두 통과
+- [ ] `agents/coders/sql.md` 가 본 작업으로 인해 변경되지 않음 (`git diff agents/coders/sql.md` 가 empty)
+- [ ] `agents/coders/python.md` 의 기존 섹션(L1-72, 기존 L73 이후) 내용이 변경되지 않고 유지됨
+
+## Notes / 특이사항
+
+- 본 phase는 단일 파일, 단일 섹션 추가 작업이므로 별도 phase 분할 불필요
+- merge 단계 (PHASE_1.5_PLAN_MERGE.md) 불필요
+- 자동 테스트 작성 불필요 (instruction 문서). 단, `PHASE_1_TEST.md` 에 사람이 수행할 검증 체크리스트 별도 명시
+- `dotclaude:code` 실행 시 본 PLAN의 Instructions 섹션을 그대로 따라 실행

--- a/claude_works/2026_04_30-python-coder-alembic-migration/PHASE_1_TEST.md
+++ b/claude_works/2026_04_30-python-coder-alembic-migration/PHASE_1_TEST.md
@@ -18,51 +18,51 @@
 
 각 FR이 신설 섹션에서 만족되는지 확인.
 
-- [ ] **FR-1 만족 검증**: `### Autogenerate-First Principle` 섹션에 다음이 모두 포함됨
-  - [ ] `alembic revision --autogenerate -m "..."` 가 기본 명령으로 명시됨
-  - [ ] 수동 작성은 autogenerate 가 처리하지 못하는 경우에만 허용됨이 명시됨
-  - [ ] bash code block 으로 명령어 예시 제공됨
+- [x] **FR-1 만족 검증**: `### Autogenerate-First Principle` 섹션에 다음이 모두 포함됨
+  - [x] `alembic revision --autogenerate -m "..."` 가 기본 명령으로 명시됨 — python.md:83
+  - [x] 수동 작성은 autogenerate 가 처리하지 못하는 경우에만 허용됨이 명시됨 — python.md:79
+  - [x] bash code block 으로 명령어 예시 제공됨 — python.md:81-84
 
-- [ ] **FR-2 만족 검증**: `### Validation Checklist (3 Steps)` 섹션에 다음이 모두 포함됨
-  - [ ] 검증 1: 변경 의도가 모두 반영되었는지 확인 절차 명시
-  - [ ] 검증 2: 의도하지 않은 변경이 detect되어 포함되지 않았는지 확인 절차 명시
-  - [ ] 검증 3: 수동 처리 필요 항목(enum, type mismatch 등) 식별 절차 명시
+- [x] **FR-2 만족 검증**: `### Validation Checklist (3 Steps)` 섹션에 다음이 모두 포함됨
+  - [x] 검증 1: 변경 의도가 모두 반영되었는지 확인 절차 명시 — python.md:93-94
+  - [x] 검증 2: 의도하지 않은 변경이 detect되어 포함되지 않았는지 확인 절차 명시 — python.md:96-100
+  - [x] 검증 3: 수동 처리 필요 항목(enum, type mismatch 등) 식별 절차 명시 — python.md:102-106
 
-- [ ] **FR-3 만족 검증**: `### Manual Edits (Reference: sql.md)` 섹션에 다음이 모두 포함됨
-  - [ ] `agents/coders/sql.md` Migration Patterns 섹션 참조가 line range (125-151) 와 함께 명시됨
-  - [ ] sql.md 를 직접 수정하지 않는다는 점이 명시됨
-  - [ ] 수동 수정 작업 주체가 python coder임이 (암시적이라도) 명확함
+- [x] **FR-3 만족 검증**: `### Manual Edits (Reference: sql.md)` 섹션에 다음이 모두 포함됨
+  - [x] `agents/coders/sql.md` Migration Patterns 섹션 참조가 line range (125-151) 와 함께 명시됨 — python.md:112
+  - [x] sql.md 를 직접 수정하지 않는다는 점이 명시됨 — python.md:113
+  - [x] 수동 수정 작업 주체가 python coder임이 (암시적이라도) 명확함 — python.md:110 ("python coder가 직접 ... sql coder를 호출하지 않는다")
 
-- [ ] **FR-4 만족 검증**: `### Local DB Verification` 섹션에 다음이 모두 포함됨
-  - [ ] `alembic upgrade head` 정상 적용 확인 단계 명시
-  - [ ] `alembic downgrade -1` -> `alembic upgrade head` 양방향 검증 명시
-  - [ ] 적용 후 schema 상태 확인 단계 명시
-  - [ ] bash code block 으로 명령어 시퀀스 제공됨
+- [x] **FR-4 만족 검증**: `### Local DB Verification` 섹션에 다음이 모두 포함됨
+  - [x] `alembic upgrade head` 정상 적용 확인 단계 명시 — python.md:130
+  - [x] `alembic downgrade -1` -> `alembic upgrade head` 양방향 검증 명시 — python.md:137-138
+  - [x] 적용 후 schema 상태 확인 단계 명시 — python.md:132-134
+  - [x] bash code block 으로 명령어 시퀀스 제공됨 — python.md:128-139
 
 ### 1.2 Edge Case 흡수 검증
 
-- [ ] **EC-1 (column drop)**: `### Validation Checklist` 검증 2 본문에 의도치 않은 변경 예시로 column drop 이 언급됨
-- [ ] **EC-2 (Enum)**: `### Validation Checklist` 검증 3 또는 `### Manual Edits` 본문에 enum 이 수동 처리 케이스로 언급됨
-- [ ] **EC-3 (Type mismatch)**: `### Validation Checklist` 검증 3 본문에 type mismatch (예: String -> Text) 가 언급됨
-- [ ] **EC-4 (downgrade 실패)**: `### Local DB Verification` 양방향 검증 단계가 downgrade 실패 사전 발견 메커니즘으로 동작함이 명확함
-- [ ] **EC-5 (Local DB 미설치)**: `### Local DB Verification` 에 사전 조건 (`DATABASE_URL`, `alembic.ini` 설정) 이 명시됨
+- [x] **EC-1 (column drop)**: `### Validation Checklist` 검증 2 본문에 의도치 않은 변경 예시로 column drop 이 언급됨 — python.md:98
+- [x] **EC-2 (Enum)**: `### Validation Checklist` 검증 3 또는 `### Manual Edits` 본문에 enum 이 수동 처리 케이스로 언급됨 — python.md:104, python.md:115
+- [x] **EC-3 (Type mismatch)**: `### Validation Checklist` 검증 3 본문에 type mismatch (예: String -> Text) 가 언급됨 — python.md:105
+- [x] **EC-4 (downgrade 실패)**: `### Local DB Verification` 양방향 검증 단계가 downgrade 실패 사전 발견 메커니즘으로 동작함이 명확함 — python.md:141 ("downgrade() 함수 누락/오류를 사전에 발견하기 위한 필수 절차")
+- [x] **EC-5 (Local DB 미설치)**: `### Local DB Verification` 에 사전 조건 (`DATABASE_URL`, `alembic.ini` 설정) 이 명시됨 — python.md:123-125
 
 ### 1.3 톤 및 일관성 검증
 
-- [ ] 명령형 톤 사용 ("Use", "Run", "Verify", "Check") - "should", "may" 같은 약한 표현 없음
-- [ ] bash code block 형식이 기존 `agents/coders/sql.md:210-222` Quality Checks 섹션과 일관
-- [ ] 헤더 레벨이 다른 `## ...` 섹션과 일관 (`##` -> `###`)
-- [ ] 외부 파일 참조 형식이 `path:line-range` 또는 `path` (lines X-Y) 패턴으로 통일
+- [x] 명령형 톤 사용 ("Use", "Run", "Verify", "Check") - "should", "may" 같은 약한 표현 없음 — "사용한다", "확인한다", "검증한다" 형태로 일관
+- [x] bash code block 형식이 기존 `agents/coders/sql.md:210-222` Quality Checks 섹션과 일관 — `# 주석` -> `명령어` 패턴 준수
+- [x] 헤더 레벨이 다른 `## ...` 섹션과 일관 (`##` -> `###`) — 1 `##` + 4 `###`, no skipping
+- [x] 외부 파일 참조 형식이 `path:line-range` 또는 `path` (lines X-Y) 패턴으로 통일 — "agents/coders/sql.md ... (lines 125-151)" 형식
 
 ## 2. Structural Lint
 
 markdown 구조 무결성 검증.
 
-- [ ] **L-1**: heading hierarchy 무결성 - `##` 섹션 헤더 1개, `###` 하위 섹션 헤더 4개. heading level skip 없음 (`##` -> `####` 직행 등)
-- [ ] **L-2**: code fence 모두 닫힘 - 신설 섹션의 ` ``` ` 개수가 짝수
-- [ ] **L-3**: 섹션 경계 spacing - `## Migration Workflow` 헤더 위/아래에 빈 줄, 각 `###` 사이에 빈 줄
-- [ ] **L-4**: 기존 섹션 무결성 - L1-72 (Preferred Stack 표 끝까지) 와 기존 L73 이후 (`## Environment Variables` 부터) 내용이 변경 없이 유지됨
-- [ ] **L-5**: list 형식 일관성 - bullet list (`-`) 또는 numbered list (`1.`) 만 사용. 한 list 안에서 mixing 없음
+- [x] **L-1**: heading hierarchy 무결성 - `##` 섹션 헤더 1개, `###` 하위 섹션 헤더 4개. heading level skip 없음 (`##` -> `####` 직행 등) — 검증 통과
+- [x] **L-2**: code fence 모두 닫힘 - 신설 섹션의 ` ``` ` 개수가 짝수 — 4개 (2 pairs)
+- [x] **L-3**: 섹션 경계 spacing - `## Migration Workflow` 헤더 위/아래에 빈 줄, 각 `###` 사이에 빈 줄 — diff 검증 통과
+- [x] **L-4**: 기존 섹션 무결성 - L1-72 (Preferred Stack 표 끝까지) 와 기존 L73 이후 (`## Environment Variables` 부터) 내용이 변경 없이 유지됨 — diff에 0 deletions
+- [x] **L-5**: list 형식 일관성 - bullet list (`-`) 또는 numbered list (`1.`) 만 사용. 한 list 안에서 mixing 없음 — Validation Checklist는 numbered, 그 외는 bullet
 
 ## 3. Cross-reference Verification
 
@@ -82,10 +82,10 @@ sed -n '143p;151p' agents/coders/sql.md
 
 ### 3.2 검증 체크리스트
 
-- [ ] **CR-1**: `agents/coders/sql.md:125` 가 `## Migration Patterns` 헤더로 시작
-- [ ] **CR-2**: `agents/coders/sql.md:151` 이 Safe Migrations 마지막 줄 (`op.alter_column('users', 'role', server_default=None)`) 임
-- [ ] **CR-3**: `agents/coders/sql.md:143` 가 `### Safe Migrations` 헤더임
-- [ ] **CR-4**: 신설 `### Manual Edits` 섹션의 모든 line range 인용이 위 사실과 일치
+- [x] **CR-1**: `agents/coders/sql.md:125` 가 `## Migration Patterns` 헤더로 시작 — `sed -n '125p'` 결과: `## Migration Patterns`
+- [x] **CR-2**: `agents/coders/sql.md:151` 이 Safe Migrations 마지막 줄 — L150이 `op.alter_column('users', 'role', server_default=None)`, L151은 닫는 ` ``` ` (Safe Migrations 코드 블록 종료). 인용 범위 125-151는 Safe Migrations subsection 종료 시점까지 정확히 포함
+- [x] **CR-3**: `agents/coders/sql.md:143` 가 `### Safe Migrations` 헤더임 — `sed -n '143p'` 결과: `### Safe Migrations`
+- [x] **CR-4**: 신설 `### Manual Edits` 섹션의 모든 line range 인용이 위 사실과 일치 — python.md:112에 "(lines 125-151) ... (lines 143-151)" 정확히 일치
 
 ### 3.3 만약 sql.md line 번호가 변동되었다면
 
@@ -104,9 +104,9 @@ sed -n '143p;151p' agents/coders/sql.md
 
 본 phase로 인해 의도하지 않은 변경이 없음을 확인.
 
-- [ ] **R-1**: `git diff agents/coders/sql.md` 결과가 empty (sql.md 무수정)
-- [ ] **R-2**: `git diff agents/coders/python.md` 결과가 신설 `## Migration Workflow` 섹션 추가 부분만 포함 (기존 line 수정/삭제 없음)
-- [ ] **R-3**: 다른 agent 정의 파일 (`agents/coders/_base.md` 등) 무수정
+- [x] **R-1**: `git diff agents/coders/sql.md` 결과가 empty (sql.md 무수정) — 검증 통과
+- [x] **R-2**: `git diff agents/coders/python.md` 결과가 신설 `## Migration Workflow` 섹션 추가 부분만 포함 (기존 line 수정/삭제 없음) — 0 deletions, 71 additions
+- [x] **R-3**: 다른 agent 정의 파일 (`agents/coders/_base.md` 등) 무수정 — `git status`상 python.md만 modified
 
 ## 5. 통과 기준 (Pass Criteria)
 

--- a/claude_works/2026_04_30-python-coder-alembic-migration/PHASE_1_TEST.md
+++ b/claude_works/2026_04_30-python-coder-alembic-migration/PHASE_1_TEST.md
@@ -1,0 +1,113 @@
+# Phase 1: 검증 체크리스트
+
+## Test Coverage Target
+
+본 phase는 instruction 문서 (markdown) 변경 작업이므로 코드 coverage 측정 대상이 아니다. 대신 다음 3축의 검증을 100% 통과해야 한다.
+
+| 검증 축 | 통과 기준 |
+|---------|----------|
+| Manual Review (FR/EC 매핑 검증) | 9개 항목 (FR-1~4 + EC-1~5) 모두 충족 |
+| Structural Lint (markdown 구조) | 5개 항목 모두 통과 |
+| Cross-reference Verification (sql.md 참조 정확성) | 2개 line range 모두 정확 |
+
+자동 테스트는 없으나 본 문서의 모든 체크리스트를 사람이 수동으로 검증한다.
+
+## 1. Manual Review Checklist
+
+### 1.1 FR 매핑 검증
+
+각 FR이 신설 섹션에서 만족되는지 확인.
+
+- [ ] **FR-1 만족 검증**: `### Autogenerate-First Principle` 섹션에 다음이 모두 포함됨
+  - [ ] `alembic revision --autogenerate -m "..."` 가 기본 명령으로 명시됨
+  - [ ] 수동 작성은 autogenerate 가 처리하지 못하는 경우에만 허용됨이 명시됨
+  - [ ] bash code block 으로 명령어 예시 제공됨
+
+- [ ] **FR-2 만족 검증**: `### Validation Checklist (3 Steps)` 섹션에 다음이 모두 포함됨
+  - [ ] 검증 1: 변경 의도가 모두 반영되었는지 확인 절차 명시
+  - [ ] 검증 2: 의도하지 않은 변경이 detect되어 포함되지 않았는지 확인 절차 명시
+  - [ ] 검증 3: 수동 처리 필요 항목(enum, type mismatch 등) 식별 절차 명시
+
+- [ ] **FR-3 만족 검증**: `### Manual Edits (Reference: sql.md)` 섹션에 다음이 모두 포함됨
+  - [ ] `agents/coders/sql.md` Migration Patterns 섹션 참조가 line range (125-151) 와 함께 명시됨
+  - [ ] sql.md 를 직접 수정하지 않는다는 점이 명시됨
+  - [ ] 수동 수정 작업 주체가 python coder임이 (암시적이라도) 명확함
+
+- [ ] **FR-4 만족 검증**: `### Local DB Verification` 섹션에 다음이 모두 포함됨
+  - [ ] `alembic upgrade head` 정상 적용 확인 단계 명시
+  - [ ] `alembic downgrade -1` -> `alembic upgrade head` 양방향 검증 명시
+  - [ ] 적용 후 schema 상태 확인 단계 명시
+  - [ ] bash code block 으로 명령어 시퀀스 제공됨
+
+### 1.2 Edge Case 흡수 검증
+
+- [ ] **EC-1 (column drop)**: `### Validation Checklist` 검증 2 본문에 의도치 않은 변경 예시로 column drop 이 언급됨
+- [ ] **EC-2 (Enum)**: `### Validation Checklist` 검증 3 또는 `### Manual Edits` 본문에 enum 이 수동 처리 케이스로 언급됨
+- [ ] **EC-3 (Type mismatch)**: `### Validation Checklist` 검증 3 본문에 type mismatch (예: String -> Text) 가 언급됨
+- [ ] **EC-4 (downgrade 실패)**: `### Local DB Verification` 양방향 검증 단계가 downgrade 실패 사전 발견 메커니즘으로 동작함이 명확함
+- [ ] **EC-5 (Local DB 미설치)**: `### Local DB Verification` 에 사전 조건 (`DATABASE_URL`, `alembic.ini` 설정) 이 명시됨
+
+### 1.3 톤 및 일관성 검증
+
+- [ ] 명령형 톤 사용 ("Use", "Run", "Verify", "Check") - "should", "may" 같은 약한 표현 없음
+- [ ] bash code block 형식이 기존 `agents/coders/sql.md:210-222` Quality Checks 섹션과 일관
+- [ ] 헤더 레벨이 다른 `## ...` 섹션과 일관 (`##` -> `###`)
+- [ ] 외부 파일 참조 형식이 `path:line-range` 또는 `path` (lines X-Y) 패턴으로 통일
+
+## 2. Structural Lint
+
+markdown 구조 무결성 검증.
+
+- [ ] **L-1**: heading hierarchy 무결성 - `##` 섹션 헤더 1개, `###` 하위 섹션 헤더 4개. heading level skip 없음 (`##` -> `####` 직행 등)
+- [ ] **L-2**: code fence 모두 닫힘 - 신설 섹션의 ` ``` ` 개수가 짝수
+- [ ] **L-3**: 섹션 경계 spacing - `## Migration Workflow` 헤더 위/아래에 빈 줄, 각 `###` 사이에 빈 줄
+- [ ] **L-4**: 기존 섹션 무결성 - L1-72 (Preferred Stack 표 끝까지) 와 기존 L73 이후 (`## Environment Variables` 부터) 내용이 변경 없이 유지됨
+- [ ] **L-5**: list 형식 일관성 - bullet list (`-`) 또는 numbered list (`1.`) 만 사용. 한 list 안에서 mixing 없음
+
+## 3. Cross-reference Verification
+
+신설 섹션이 인용하는 sql.md line range 가 실제와 일치하는지 검증.
+
+### 3.1 정확성 검증 절차
+
+다음 명령으로 sql.md 해당 line 의 실제 내용 확인.
+
+```bash
+# Migration Patterns 섹션 시작/끝 확인
+sed -n '125p;151p' agents/coders/sql.md
+
+# Safe Migrations subsection 확인
+sed -n '143p;151p' agents/coders/sql.md
+```
+
+### 3.2 검증 체크리스트
+
+- [ ] **CR-1**: `agents/coders/sql.md:125` 가 `## Migration Patterns` 헤더로 시작
+- [ ] **CR-2**: `agents/coders/sql.md:151` 이 Safe Migrations 마지막 줄 (`op.alter_column('users', 'role', server_default=None)`) 임
+- [ ] **CR-3**: `agents/coders/sql.md:143` 가 `### Safe Migrations` 헤더임
+- [ ] **CR-4**: 신설 `### Manual Edits` 섹션의 모든 line range 인용이 위 사실과 일치
+
+### 3.3 만약 sql.md line 번호가 변동되었다면
+
+본 phase 작업 전에 `agents/coders/sql.md` 가 변경되어 line 번호가 달라진 경우, 다음 절차를 따름.
+
+1. 실제 Migration Patterns 섹션 line range 확인:
+   ```bash
+   grep -n '^## Migration Patterns' agents/coders/sql.md
+   grep -n '^## ' agents/coders/sql.md  # 다음 ## 헤더 line 으로 끝 line 추정
+   ```
+2. 신설 `### Manual Edits` 섹션의 인용 line range 를 실제 값으로 업데이트
+3. 본 TEST 문서의 CR-1 ~ CR-3 도 함께 업데이트
+4. SPEC.md L48, L80 의 line 번호도 동일하게 업데이트 필요한지 확인 후 별도 보고
+
+## 4. 회귀 검증 (Regression)
+
+본 phase로 인해 의도하지 않은 변경이 없음을 확인.
+
+- [ ] **R-1**: `git diff agents/coders/sql.md` 결과가 empty (sql.md 무수정)
+- [ ] **R-2**: `git diff agents/coders/python.md` 결과가 신설 `## Migration Workflow` 섹션 추가 부분만 포함 (기존 line 수정/삭제 없음)
+- [ ] **R-3**: 다른 agent 정의 파일 (`agents/coders/_base.md` 등) 무수정
+
+## 5. 통과 기준 (Pass Criteria)
+
+위 1-4 의 모든 체크박스가 체크되어야 본 phase 가 PASS 처리된다. 하나라도 실패 시 PHASE_1_PLAN_alembic-migration.md 의 Instructions 로 돌아가 해당 항목을 보완한 후 재검증.

--- a/claude_works/2026_04_30-python-coder-alembic-migration/SPEC.md
+++ b/claude_works/2026_04_30-python-coder-alembic-migration/SPEC.md
@@ -1,0 +1,97 @@
+<!-- dotclaude-config
+working_directory: claude_works
+base_branch: main
+language: ko_KR
+worktree_path: ../dotclaude-feature-python-coder-alembic-migration
+doc_dir: 2026_04_30-python-coder-alembic-migration
+-->
+
+# SPEC: Python Coder - Alembic Migration Autogenerate 기본화
+
+## Metadata
+
+| 항목 | 값 |
+|------|-----|
+| Source Issue | https://github.com/U-lis/dotclaude/issues/62 |
+| Target Version | 0.5.0 |
+| Work Type | feature |
+| Branch | feature/python-coder-alembic-migration |
+
+## Overview / 목표
+
+Python coder 에이전트가 Alembic migration을 작성할 때 기본 워크플로우로 `alembic revision --autogenerate` 를 사용하도록 `agents/coders/python.md` instruction을 업데이트한다. autogenerate 결과의 검증, 수동 수정이 필요한 경우의 참조 가이드, local DB 적용 확인까지 모두 python coder의 표준 절차로 명시한다.
+
+Migration 작업의 주체는 python coder이며, sql coder가 아니다. 검증 후 수동 수정이 필요한 경우 `agents/coders/sql.md`의 기존 Migration Patterns / Safe Migrations 섹션을 참조하여 올바른 문법으로 직접 작성한다.
+
+## Problem / 해결하려는 문제
+
+현재 instruction에는 Alembic이 사용 도구로만 언급되어 있고 (`agents/coders/python.md:70` Preferred Stack), 실제 migration 작성 워크플로우는 어디에도 명시되지 않았다. 또한 `agents/coders/sql.md:125-151` 의 Migration Patterns 섹션에는 수동 작성 예시 (`op.create_index()`, `op.add_column()` 등)만 제공되어 있다. 이로 인해 다음과 같은 문제가 발생한다.
+
+- python coder가 migration 작업 시 autogenerate workflow를 따르지 않아 실수와 누락이 발생
+- 검증 절차가 없어 의도치 않은 변경이 migration에 포함될 가능성 존재
+- migration이 실제 local DB에서 동작하는지 확인하지 않은 채 commit되는 경우 발생
+- 수동 수정이 필요한 경우 어떤 자료를 참조해야 하는지 명시되지 않음
+
+## Functional Requirements / 핵심 기능
+
+- [ ] **FR-1: python.md에 Autogenerate 우선 워크플로우 가이드 추가**
+  - 가이드 위치: `agents/coders/python.md`
+  - `alembic revision --autogenerate -m "..."`을 기본 명령으로 명시
+  - 수동 작성은 autogenerate가 처리하지 못하는 경우(enum 변경 등)에만 사용한다는 원칙 명시
+
+- [ ] **FR-2: Autogenerate 결과 3단계 검증 절차 명시 (python.md)**
+  - 검증 1: 변경하고자 하는 것이 모두 반영되었는가
+  - 검증 2: 변경하고자 하지 않은 것이 detect되어 포함되지 않았는가
+  - 검증 3: 수동 처리 필요 항목(enum 변경, type mismatch 등) 식별
+
+- [ ] **FR-3: 수동 수정 가이드 (sql.md 참조 명시)**
+  - 검증 단계에서 수정 필요 항목 발견 시 `agents/coders/sql.md`의 Migration Patterns 및 Safe Migrations 섹션 (line 125-151)을 참조하여 올바른 문법으로 직접 수정
+  - sql.md를 직접 수정하지 않음 (참조용 유지)
+
+- [ ] **FR-4: Local DB 적용 검증 절차 명시 (python.md)**
+  - `alembic upgrade head` 실행하여 정상 적용 확인
+  - `alembic downgrade -1` 후 다시 `alembic upgrade head` 로 양방향 동작 검증
+  - 적용 후 schema 상태 확인 단계 명시
+
+## Non-Functional Requirements
+
+- [ ] **NFR-1: 성능** — 별도 요구사항 없음 (instruction 문서 개선 작업)
+- [ ] **NFR-2: 보안** — 별도 요구사항 없음
+
+## Constraints / 제약사항
+
+- 기존 codebase 패턴 준수 (다른 coder agent instruction 형식과 일관성 유지)
+- 기술 스택: Alembic, SQLAlchemy 2.0+, PostgreSQL (기존 Preferred Stack 유지)
+- Migration 작업 주체는 python coder (sql coder가 아님)
+
+## Out of Scope / 범위 제외
+
+- enum 변경 등 autogenerate가 정확히 처리하지 못하는 케이스는 자동화 범위 외 (수동 작성 가이드만 제공)
+- Alembic 이외 migration 도구 (Prisma 등) 가이드 변경 없음
+- `agents/coders/sql.md`는 구조/예시 변경 없음 (참조용으로 유지)
+
+## Analysis Results / 분석 결과
+
+### Related Code
+
+| # | File | Line | Relationship |
+|---|------|------|--------------|
+| 1 | agents/coders/python.md | 70 | Alembic이 Preferred Stack에만 언급되고 workflow 가이드 부재 |
+| 2 | agents/coders/sql.md | 125-151 | Migration Patterns 섹션에 수동 작성 예시 존재 (참조용으로 활용) |
+| 3 | agents/coders/sql.md | 211-222 | Quality Checks 섹션에 alembic 명령어는 있으나 autogenerate workflow 부재 |
+
+### Conflicts Identified
+
+| # | Existing Behavior | Required Behavior | Resolution |
+|---|-------------------|-------------------|------------|
+| 1 | python.md에 migration workflow 언급 없음 (line 70만 Preferred Stack) | python coder가 autogenerate workflow + 검증 + 수동 수정 절차를 알아야 함 | python.md에 Migration Workflow 섹션 신설. 수동 수정 시 sql.md (line 125-151) 참조하도록 명시 |
+
+### Edge Cases
+
+| # | Case | Expected Behavior |
+|---|------|-------------------|
+| 1 | autogenerate가 의도하지 않은 column drop을 detect | 검증 단계에서 식별 → 해당 변경을 migration에서 제거 |
+| 2 | Enum type 변경 (PostgreSQL ENUM 추가/제거) | autogenerate가 정확히 처리 못함 → sql.md 참조하여 수동 작성 |
+| 3 | Type mismatch (e.g., String → Text) | autogenerate detect되나 명시적 검토 필요 → 검증 체크리스트 항목 |
+| 4 | Migration upgrade는 성공하나 downgrade 실패 | upgrade/downgrade 양방향 검증 단계에서 사전 발견 |
+| 5 | Local DB 미설치 환경 | 사전 조건 명시 (DATABASE_URL, alembic.ini 설정 확인) |


### PR DESCRIPTION
## Summary

- Python coder 에이전트가 Alembic migration 작성 시 `alembic revision --autogenerate -m "..."` 를 기본 워크플로우로 사용하도록 instruction을 업데이트
- 3단계 검증 절차 (의도 변경 반영 / 의도하지 않은 변경 누락 / 수동 처리 항목 식별) 명시
- 수동 수정이 필요한 경우 `agents/coders/sql.md` Migration Patterns (lines 125-151) 참조하도록 cross-reference 추가
- `alembic upgrade head` ↔ `alembic downgrade -1` 양방향 local DB 검증 절차 명시

Resolves #62

## Changes

- `agents/coders/python.md`: Preferred Stack 표(L72)와 Environment Variables(L73) 사이에 `## Migration Workflow` 섹션 신설 (4개 하위 섹션: Autogenerate-First Principle, Validation Checklist, Manual Edits, Local DB Verification)
- `CHANGELOG.md`: v0.5.0 entry 추가
- `claude_works/2026_04_30-python-coder-alembic-migration/SPEC.md`: 작업 스펙 문서
- `claude_works/2026_04_30-python-coder-alembic-migration/GLOBAL.md`: 단일 phase 개요 + AD-1~6 아키텍처 결정
- `claude_works/2026_04_30-python-coder-alembic-migration/PHASE_1_PLAN_alembic-migration.md`: 7개 checklist (C-1~7) + Edge Case 흡수 매핑
- `claude_works/2026_04_30-python-coder-alembic-migration/PHASE_1_TEST.md`: Manual Review / Structural Lint / Cross-reference 3축 검증

## Test plan

- [ ] `agents/coders/python.md`의 새 `## Migration Workflow` 섹션이 Preferred Stack 직후, Environment Variables 직전에 위치하는지 확인
- [ ] 4개 하위 섹션이 SPEC FR-1 ~ FR-4와 1:1로 매핑되는지 확인
- [ ] Autogenerate-First Principle: `alembic revision --autogenerate -m "..."` 명령과 수동 작성 예외 원칙 명시 확인
- [ ] Validation Checklist 3단계가 의도 변경 / 의도하지 않은 변경(column drop) / 수동 처리(enum, type mismatch) 모두 다루는지 확인
- [ ] Manual Edits 섹션이 `agents/coders/sql.md` lines 125-151 정확히 참조하는지, sql.md 미수정 원칙 명시 확인
- [ ] Local DB Verification에 DATABASE_URL/alembic.ini 사전 조건 + `alembic upgrade head` ↔ `alembic downgrade -1` 양방향 검증 bash 블록 확인
- [ ] `agents/coders/sql.md` 변경 없음 확인 (`git diff main..HEAD -- agents/coders/sql.md` empty)
- [ ] python.md 기존 본문(L1~L72, 원래 L73~끝) 변경 없음 (insert only) 확인
- [ ] CHANGELOG.md v0.5.0 entry가 Keep a Changelog 형식 준수 + 기존 0.4.0 이하 entry 미수정 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)